### PR TITLE
MCUB-3 Add sample Mynewt boot app.

### DIFF
--- a/apps/boot/README.md
+++ b/apps/boot/README.md
@@ -1,0 +1,6 @@
+# mcuboot - apps/boot
+
+This sample app implements a boot loader for the Mynewt OS (apache.mynewt.org).
+This app requires the following Mynewt repositories:
+    * @mcuboot (this one)
+    * @apache-mynewt-core

--- a/apps/boot/pkg.yml
+++ b/apps/boot/pkg.yml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: apps/boot
+pkg.type: app
+pkg.description: Boot loader application.
+pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"
+pkg.keywords:
+    - loader
+
+pkg.deps:
+    - "@mcuboot/boot/bootutil"
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/stub"
+
+pkg.deps.BOOT_SERIAL.OVERWRITE:
+    - "@apache-mynewt-core/sys/console/full"
+    - "@mcuboot/boot/boot_serial"

--- a/apps/boot/src/boot.c
+++ b/apps/boot/src/boot.c
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <inttypes.h>
+#include "syscfg/syscfg.h"
+#include <flash_map/flash_map.h>
+#include <os/os.h>
+#include <bsp/bsp.h>
+#include <hal/hal_bsp.h>
+#include <hal/hal_system.h>
+#include <hal/hal_flash.h>
+#if MYNEWT_VAL(BOOT_SERIAL)
+#include <hal/hal_gpio.h>
+#include <boot_serial/boot_serial.h>
+#include <sysinit/sysinit.h>
+#endif
+#include <console/console.h>
+#include "bootutil/image.h"
+#include "bootutil/bootutil.h"
+
+#define BOOT_AREA_DESC_MAX  (256)
+#define AREA_DESC_MAX       (BOOT_AREA_DESC_MAX)
+
+#if MYNEWT_VAL(BOOT_SERIAL)
+#define BOOT_SER_CONS_INPUT         128
+#endif
+
+int
+main(void)
+{
+    struct boot_rsp rsp;
+    int rc;
+
+#if MYNEWT_VAL(BOOT_SERIAL)
+    sysinit();
+#else
+    flash_map_init();
+    hal_bsp_init();
+#endif
+
+#if MYNEWT_VAL(BOOT_SERIAL)
+    /*
+     * Configure a GPIO as input, and compare it against expected value.
+     * If it matches, await for download commands from serial.
+     */
+    hal_gpio_init_in(BOOT_SERIAL_DETECT_PIN, BOOT_SERIAL_DETECT_PIN_CFG);
+    if (hal_gpio_read(BOOT_SERIAL_DETECT_PIN) == BOOT_SERIAL_DETECT_PIN_VAL) {
+        boot_serial_start(BOOT_SER_CONS_INPUT);
+        assert(0);
+    }
+#endif
+    rc = boot_go(&rsp);
+    assert(rc == 0);
+
+    hal_system_start((void *)(rsp.br_image_addr + rsp.br_hdr->ih_hdr_size));
+
+    return 0;
+}

--- a/apps/boot/syscfg.yml
+++ b/apps/boot/syscfg.yml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: apps/boot
+
+syscfg.defs:
+    BOOT_LOADER:
+        description: 'TBD'
+        value: 1
+    BOOT_SERIAL:
+        description: 'TBD'
+        value: 0
+
+syscfg.vals:
+    SYSINIT_CONSTRAIN_INIT: 0
+    OS_SCHEDULING: 0
+    OS_CPUTIME_TIMER_NUM: -1


### PR DESCRIPTION
This commit implements the sample Mynewt boot app.

I'm a little uncertain about the directory structure (apps/boot).  I chose one that makes sense for Mynewt.  I think I am not familiar enough with Zephyr to know how anti-social this is.  Other options are:
* Rename app to mynewt-boot; other OS apps are siblings.
* Create OS-specific top-level directories (mynewt/apps/boot).

I don't think it is a problem to rearrange things when we have a better idea of what we're going for, so I opted for simplicity for now.