### PR TITLE
Logging

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil_log.h
+++ b/boot/bootutil/include/bootutil/bootutil_log.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017 Linaro Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef H_BOOTUTIL_LOG_H_
+#define H_BOOTUTIL_LOG_H_
+
+#include "ignore.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * When building for targets running Zephyr, delegate to its native
+ * logging subsystem.
+ *
+ * In this case:
+ *
+ * - BOOT_LOG_LEVEL determines SYS_LOG_LEVEL,
+ * - BOOT_LOG_ERR() and friends are SYS_LOG_ERR() etc.
+ * - SYS_LOG_DOMAIN is unconditionally set to "MCUBOOT"
+ */
+#ifdef __ZEPHYR__
+
+#define BOOT_LOG_LEVEL_OFF	SYS_LOG_LEVEL_OFF
+#define BOOT_LOG_LEVEL_ERROR	SYS_LOG_LEVEL_ERROR
+#define BOOT_LOG_LEVEL_WARNING	SYS_LOG_LEVEL_WARNING
+#define BOOT_LOG_LEVEL_INFO	SYS_LOG_LEVEL_INFO
+#define BOOT_LOG_LEVEL_DEBUG	SYS_LOG_LEVEL_DEBUG
+
+/* Treat BOOT_LOG_LEVEL equivalently to SYS_LOG_LEVEL. */
+#ifndef BOOT_LOG_LEVEL
+#define BOOT_LOG_LEVEL CONFIG_SYS_LOG_DEFAULT_LEVEL
+#elif (BOOT_LOG_LEVEL < CONFIG_SYS_LOG_OVERRIDE_LEVEL)
+#undef BOOT_LOG_LEVEL
+#define BOOT_LOG_LEVEL CONFIG_SYS_LOG_OVERRIDE_LEVEL
+#endif
+
+#define SYS_LOG_LEVEL BOOT_LOG_LEVEL
+
+#undef SYS_LOG_DOMAIN
+#define SYS_LOG_DOMAIN "MCUBOOT"
+
+#define BOOT_LOG_ERR(...) SYS_LOG_ERR(__VA_ARGS__)
+#define BOOT_LOG_WRN(...) SYS_LOG_WRN(__VA_ARGS__)
+#define BOOT_LOG_INF(...) SYS_LOG_INF(__VA_ARGS__)
+#define BOOT_LOG_DBG(...) SYS_LOG_DBG(__VA_ARGS__)
+
+#include <logging/sys_log.h>
+
+/*
+ * In other environments, logging calls are no-ops.
+ */
+#else  /* !defined(__ZEPHYR__) */
+
+#define BOOT_LOG_LEVEL_OFF	0
+#define BOOT_LOG_LEVEL_ERROR	1
+#define BOOT_LOG_LEVEL_WARNING	2
+#define BOOT_LOG_LEVEL_INFO	3
+#define BOOT_LOG_LEVEL_DEBUG	4
+
+#define BOOT_LOG_ERR(...) IGNORE(__VA_ARGS__)
+#define BOOT_LOG_WRN(...) IGNORE(__VA_ARGS__)
+#define BOOT_LOG_INF(...) IGNORE(__VA_ARGS__)
+#define BOOT_LOG_DBG(...) IGNORE(__VA_ARGS__)
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/boot/bootutil/include/bootutil/ignore.h
+++ b/boot/bootutil/include/bootutil/ignore.h
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef H_IGNORE_
+#define H_IGNORE_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * These macros prevent the "set but not used" warnings for log writes below
+ * the log level.
+ */
+
+#define IGN_1(X) ((void)(X))
+#define IGN_2(X, ...) ((void)(X));IGN_1(__VA_ARGS__)
+#define IGN_3(X, ...) ((void)(X));IGN_2(__VA_ARGS__)
+#define IGN_4(X, ...) ((void)(X));IGN_3(__VA_ARGS__)
+#define IGN_5(X, ...) ((void)(X));IGN_4(__VA_ARGS__)
+#define IGN_6(X, ...) ((void)(X));IGN_5(__VA_ARGS__)
+#define IGN_7(X, ...) ((void)(X));IGN_6(__VA_ARGS__)
+#define IGN_8(X, ...) ((void)(X));IGN_7(__VA_ARGS__)
+#define IGN_9(X, ...) ((void)(X));IGN_8(__VA_ARGS__)
+#define IGN_10(X, ...) ((void)(X));IGN_9(__VA_ARGS__)
+#define IGN_11(X, ...) ((void)(X));IGN_10(__VA_ARGS__)
+#define IGN_12(X, ...) ((void)(X));IGN_11(__VA_ARGS__)
+#define IGN_13(X, ...) ((void)(X));IGN_12(__VA_ARGS__)
+#define IGN_14(X, ...) ((void)(X));IGN_13(__VA_ARGS__)
+#define IGN_15(X, ...) ((void)(X));IGN_14(__VA_ARGS__)
+#define IGN_16(X, ...) ((void)(X));IGN_15(__VA_ARGS__)
+#define IGN_17(X, ...) ((void)(X));IGN_16(__VA_ARGS__)
+#define IGN_18(X, ...) ((void)(X));IGN_17(__VA_ARGS__)
+#define IGN_19(X, ...) ((void)(X));IGN_18(__VA_ARGS__)
+#define IGN_20(X, ...) ((void)(X));IGN_19(__VA_ARGS__)
+
+#define GET_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, \
+                  _13, _14, _15, _16, _17, _18, _19, _20, NAME, ...) NAME
+#define IGNORE(...) \
+    GET_MACRO(__VA_ARGS__, IGN_20, IGN_19, IGN_18, IGN_17, IGN_16, IGN_15, \
+              IGN_14, IGN_13, IGN_12, IGN_11, IGN_10, IGN_9, IGN_8, IGN_7, \
+              IGN_6, IGN_5, IGN_4, IGN_3, IGN_2, IGN_1)(__VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/boot/zephyr/flash_map.c
+++ b/boot/zephyr/flash_map.c
@@ -26,9 +26,8 @@
 #include <hal/hal_flash.h>
 #include <sysflash/sysflash.h>
 
-#define SYS_LOG_DOMAIN "BOOTLOADER"
-#define SYS_LOG_LEVEL SYS_LOG_LEVEL_INFO
-#include <logging/sys_log.h>
+#define BOOT_LOG_LEVEL BOOT_LOG_LEVEL_INFO
+#include "bootutil/bootutil_log.h"
 
 extern struct device *boot_flash_device;
 
@@ -62,7 +61,7 @@ int flash_area_open(uint8_t id, const struct flash_area **area)
 {
 	int i;
 
-	SYS_LOG_DBG("%s: area %d", __func__, id);
+	BOOT_LOG_DBG("%s: area %d", __func__, id);
 
 	for (i = 0; i < ARRAY_SIZE(part_map); i++) {
 		if (id == part_map[i].fa_id)
@@ -85,8 +84,8 @@ void flash_area_close(const struct flash_area *area)
 int flash_area_read(const struct flash_area *area, uint32_t off, void *dst,
 		    uint32_t len)
 {
-	SYS_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__,
-			area->fa_id, off, len);
+	BOOT_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__,
+		     area->fa_id, off, len);
 	return flash_read(boot_flash_device, area->fa_off + off, dst, len);
 }
 
@@ -95,8 +94,8 @@ int flash_area_write(const struct flash_area *area, uint32_t off, const void *sr
 {
 	int rc = 0;
 
-	SYS_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__,
-			area->fa_id, off, len);
+	BOOT_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__,
+		     area->fa_id, off, len);
 	flash_write_protection_set(boot_flash_device, false);
 	rc = flash_write(boot_flash_device, area->fa_off + off, src, len);
 	flash_write_protection_set(boot_flash_device, true);
@@ -105,8 +104,8 @@ int flash_area_write(const struct flash_area *area, uint32_t off, const void *sr
 
 int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len)
 {
-	SYS_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__,
-			area->fa_id, off, len);
+	BOOT_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__,
+		     area->fa_id, off, len);
 	return flash_erase(boot_flash_device, area->fa_off + off, len);
 }
 
@@ -136,7 +135,7 @@ int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
 	uint32_t len;
 	uint32_t max_cnt = *cnt;
 
-	SYS_LOG_DBG("%s: lookup area %d", __func__, idx);
+	BOOT_LOG_DBG("%s: lookup area %d", __func__, idx);
 	/*
 	 * This simple layout has uniform slots, so just fill in the
 	 * right one.

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -18,9 +18,8 @@
 #include <flash.h>
 #include <asm_inline.h>
 
-#define SYS_LOG_DOMAIN "BOOTLOADER"
-#define SYS_LOG_LEVEL SYS_LOG_LEVEL_INFO
-#include <logging/sys_log.h>
+#define BOOT_LOG_LEVEL BOOT_LOG_LEVEL_INFO
+#include "bootutil/bootutil_log.h"
 
 #if defined(MCUBOOT_TARGET_CONFIG)
 #include MCUBOOT_TARGET_CONFIG
@@ -46,34 +45,34 @@ void main(void)
 	struct vector_table *vt;
 	int rc;
 
-	SYS_LOG_INF("Starting bootloader");
+	BOOT_LOG_INF("Starting bootloader");
 
 	os_heap_init();
 
 	boot_flash_device = device_get_binding(FLASH_DRIVER_NAME);
 	if (!boot_flash_device) {
-		SYS_LOG_ERR("Flash device not found");
+		BOOT_LOG_ERR("Flash device not found");
 		while (1)
 			;
 	}
 
 	rc = boot_go(&rsp);
 	if (rc != 0) {
-		SYS_LOG_ERR("Unable to find bootable image");
+		BOOT_LOG_ERR("Unable to find bootable image");
 		while (1)
 			;
 	}
 
-	SYS_LOG_INF("Bootloader chainload address: 0x%x", rsp.br_image_addr);
+	BOOT_LOG_INF("Bootloader chainload address: 0x%x", rsp.br_image_addr);
 	vt = (struct vector_table *)(rsp.br_image_addr +
 				     rsp.br_hdr->ih_hdr_size);
 	irq_lock();
 	_MspSet(vt->msp);
 
-	SYS_LOG_INF("Jumping to the first image slot");
+	BOOT_LOG_INF("Jumping to the first image slot");
 	((void (*)(void))vt->reset)();
 
-	SYS_LOG_ERR("Never should get here");
+	BOOT_LOG_ERR("Never should get here");
 	while (1)
 		;
 }


### PR DESCRIPTION
This patch series adds a common logging abstraction to mcuboot, which targets can customize to use their logging backends. Currently, a no-op backend for the simulator and a Zephyr-specific backend are provided.

Simulator tests all pass:

```
plop: sim (logging) mbolivar$ ./target/release/bootsim run --device k64f
ERROR:bootsim: 0 out of 577 failed 0.00%
1|plop: sim (logging) mbolivar$ ./target/release/bootsim run --device Stm32f4
ERROR:bootsim: 0 out of 391 failed 0.00%
plop: sim (logging) mbolivar$ ./target/release/bootsim run --device K64fBig
ERROR:bootsim: 0 out of 391 failed 0.00%
```

This may interact with https://github.com/runtimeco/mcuboot/pull/14.
