### PR TITLE
zephyr: targets: update flash driver names to use Zephyr CONFIGs

### DIFF
--- a/boot/zephyr/flash_map.c
+++ b/boot/zephyr/flash_map.c
@@ -104,9 +104,14 @@ int flash_area_write(const struct flash_area *area, uint32_t off, const void *sr
 
 int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len)
 {
+	int rc;
+
 	BOOT_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__,
-		     area->fa_id, off, len);
-	return flash_erase(boot_flash_device, area->fa_off + off, len);
+			area->fa_id, off, len);
+	flash_write_protection_set(boot_flash_device, false);
+	rc = flash_erase(boot_flash_device, area->fa_off + off, len);
+	flash_write_protection_set(boot_flash_device, true);
+	return rc;
 }
 
 uint8_t flash_area_align(const struct flash_area *area)

--- a/boot/zephyr/targets/96b_carbon.h
+++ b/boot/zephyr/targets/96b_carbon.h
@@ -19,7 +19,12 @@
  * @brief Bootloader device specific configuration.
  */
 
+/* TEMP: maintain compatibility with old STM flash driver */
+#ifndef CONFIG_SOC_FLASH_STM32_DEV_NAME
 #define FLASH_DRIVER_NAME		"STM32F4_FLASH"
+#else
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_STM32_DEV_NAME
+#endif
 #define FLASH_ALIGN			1
 #define FLASH_AREA_IMAGE_0_OFFSET	0x20000
 #define FLASH_AREA_IMAGE_0_SIZE		0x20000

--- a/boot/zephyr/targets/96b_nitrogen.h
+++ b/boot/zephyr/targets/96b_nitrogen.h
@@ -19,7 +19,7 @@
  * @brief Bootloader device specific configuration.
  */
 
-#define FLASH_DRIVER_NAME		"NRF5_FLASH"
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_NRF5_DEV_NAME
 #define FLASH_ALIGN			4
 #define FLASH_AREA_IMAGE_0_OFFSET	0x08000
 #define FLASH_AREA_IMAGE_0_SIZE		0x3A000

--- a/boot/zephyr/targets/frdm_k64f.h
+++ b/boot/zephyr/targets/frdm_k64f.h
@@ -19,7 +19,7 @@
  * @brief Bootloader device specific configuration.
  */
 
-#define FLASH_DRIVER_NAME		"MCUX_FLASH"
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_MCUX_DEV_NAME
 #define FLASH_ALIGN			8
 #define FLASH_AREA_IMAGE_0_OFFSET	0x20000
 #define FLASH_AREA_IMAGE_0_SIZE		0x20000

--- a/boot/zephyr/targets/nucleo_f401re.h
+++ b/boot/zephyr/targets/nucleo_f401re.h
@@ -19,7 +19,7 @@
  * @brief Bootloader device specific configuration.
  */
 
-#define FLASH_DRIVER_NAME		"STM32F4_FLASH"
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_STM32_DEV_NAME
 #define FLASH_ALIGN			1
 #define FLASH_AREA_IMAGE_0_OFFSET	0x20000
 #define FLASH_AREA_IMAGE_0_SIZE		0x20000


### PR DESCRIPTION
Let's stay in-sync automatically with Zephyr master by referring
to CONFIGs for the flash device names.

Signed-off-by: Michael Scott <michael.scott@linaro.org>