### PR TITLE
Fix slot0 validation

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -580,22 +580,20 @@ boot_validate_slot(int slot)
         return -1;
     }
 
-    /* Image in slot 1 is invalid.  Erase the image and continue booting
-     * from slot 0.
-     */
     rc = flash_area_open(flash_area_id_from_image_slot(slot), &fap);
     if (rc != 0) {
         return BOOT_EFLASH;
     }
 
     if ((boot_data.imgs[slot].hdr.ih_magic != IMAGE_MAGIC ||
-	 boot_image_check(&boot_data.imgs[slot].hdr, fap) != 0) &&
-	slot == 1) {
+         boot_image_check(&boot_data.imgs[slot].hdr, fap) != 0)) {
 
-        /* Image in slot 1 is invalid.  Erase the image and continue booting
-         * from slot 0.
-         */
-        flash_area_erase(fap, 0, fap->fa_size);
+        if (slot != 0) {
+            flash_area_erase(fap, 0, fap->fa_size);
+            /* Image in slot 1 is invalid. Erase the image and
+             * continue booting from slot 0.
+             */
+        }
         return -1;
     }
 


### PR DESCRIPTION
    commit d930ec69c835b83ba933677d29760ba7605a1158
    Author: David Brown <david.brown@linaro.org>
    Date:   Wed Dec 14 07:59:48 2016 -0700

        Validate slot zero before booting

adds a feature to validate slot 0 before booting it.  However, there
is an error in the logic, and if the magic number is written to an
invalid value, but not all 0xFF, it will consider any image to be
valid.

Fix this logic so that slot zero is always validated.