### PR TITLE
zep2newt.py: use /usr/bin/env when searching for python2

### DIFF
--- a/scripts/zep2newt.py
+++ b/scripts/zep2newt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python2
 
 from __future__ import print_function
 


### PR DESCRIPTION
Avoid hardcoding the python2 path by using env python2 instead.

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>