### PR TITLE
Fix 8-byte aligned sector failure

### DIFF
--- a/boot/bootutil/design.txt
+++ b/boot/bootutil/design.txt
@@ -337,7 +337,7 @@ A. Inspect swap status region; is an interrupted swap is being resumed?
     Yes: Complete the partial swap operation; skip to step C.
     No: Proceed to step B.
 
-B. Insect boot vector; is a swap requested?
+B. Inspect boot vector; is a swap requested?
     Yes.
         1. Is the requested image valid (integrity and security check)?
             Yes.

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -40,6 +40,8 @@ extern "C" {
 
 #define BOOT_SWAP_TYPE_FAIL     0xff
 
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+
 struct image_header;
 /**
  * A response object provided by the boot loader code; indicates where to jump

--- a/sim/src/api.rs
+++ b/sim/src/api.rs
@@ -29,6 +29,9 @@ pub extern fn sim_flash_write(dev: *mut Flash, offset: u32, src: *const u8, size
 fn map_err(err: Result<()>) -> libc::c_int {
     match err {
         Ok(()) => 0,
-        Err(_) => -1,
+        Err(e) => {
+            warn!("{}", e);
+            -1
+        },
     }
 }

--- a/sim/src/flash.rs
+++ b/sim/src/flash.rs
@@ -94,8 +94,10 @@ impl Flash {
         }
 
         let mut sub = &mut self.data[offset .. offset + payload.len()];
-        if sub.iter().any(|x| *x != 0xFF) {
-            bail!(ewrite(format!("Write to non-FF location: offset: {:x}", offset)));
+        for (i, x) in sub.iter().enumerate() {
+            if *x != 0xFF {
+                bail!(ewrite(format!("Write to non-FF location at 0x{:x}", offset + i)));
+            }
         }
 
         sub.copy_from_slice(payload);

--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -38,7 +38,7 @@ Options:
   -h, --help         Show this message
   --version          Version
   --device TYPE      MCU to simulate
-                     Valid values: stm32f4, k64f
+                     Valid values: stm32f4, k64f, k64fbig, nrf52840
   --align SIZE       Flash write alignment
 ";
 


### PR DESCRIPTION
This fixes issue MCUB-36.

While copying data from slot to slot, if using 8-byte aligned
sectors, not all boot status data falls in the same copy buffer
which might result in inconsistency of state if a reset occurs
before all boot status sectors were copied.