### PR TITLE
Back out unneeded part of random reset test

### DIFF
--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -9,7 +9,7 @@ extern crate rustc_serialize;
 extern crate error_chain;
 
 use docopt::Docopt;
-use rand::{Rng, SeedableRng, XorShiftRng, thread_rng};
+use rand::{Rng, SeedableRng, XorShiftRng};
 use rand::distributions::{IndependentSample, Range};
 use rustc_serialize::{Decodable, Decoder};
 use std::fmt;
@@ -234,9 +234,8 @@ impl RunStatus {
         }
 
         let mut bad = 0;
-        let mut stops: Vec<i32> = (1..total_count).collect();
-        thread_rng().shuffle(stops.as_mut_slice());
-        for i in stops {
+        // Let's try an image halfway through.
+        for i in 1 .. total_count {
             info!("Try interruption at {}", i);
             let (fl3, total_count) = try_upgrade(&flash, &areadesc, Some(i));
             info!("Second boot, count={}", total_count);


### PR DESCRIPTION
In change

    commit bb5635e07439c809d055d3413844c394c0b1b4bc
    Author: Fabio Utzig <utzig@utzig.org>
    Date:   Mon Apr 10 09:07:02 2017 -0300

        Add test of multiple random resets while upgrading

in addition to adding the try_random_fails, it shuffled the order that
the initial interruption test ran.  However, this test always clones
the flash device, so it doesn't matter what order the tests are run.
Revert this part of the change to avoid unnecessary complexity in the
code.