### PR TITLE
Move trailer magic to end

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -33,12 +33,14 @@
 
 int boot_current_slot;
 
-const uint32_t boot_img_magic[4] = {
+const uint32_t boot_img_magic[] = {
     0xf395c277,
     0x7fefd260,
     0x0f505235,
     0x8079b62c,
 };
+
+const uint32_t BOOT_MAGIC_SZ = sizeof boot_img_magic;
 
 struct boot_swap_table {
     /** * For each field, a value of 0 means "any". */
@@ -144,11 +146,11 @@ boot_magic_code(const uint32_t *magic)
 {
     int i;
 
-    if (memcmp(magic, boot_img_magic, sizeof boot_img_magic) == 0) {
+    if (memcmp(magic, boot_img_magic, BOOT_MAGIC_SZ) == 0) {
         return BOOT_MAGIC_GOOD;
     }
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < BOOT_MAGIC_SZ; i++) {
         if (magic[i] == 0xffffffff) {
             return BOOT_MAGIC_UNSET;
         }
@@ -166,13 +168,13 @@ boot_status_sz(uint8_t min_write_sz)
 uint32_t
 boot_trailer_sz(uint8_t min_write_sz)
 {
-    return sizeof boot_img_magic            +
-           boot_status_sz(min_write_sz)     +
+    return BOOT_MAGIC_SZ                +
+           boot_status_sz(min_write_sz) +
            min_write_sz * 2;
 }
 
 static uint32_t
-boot_magic_off(const struct flash_area *fap)
+boot_trailer_off(const struct flash_area *fap)
 {
     uint32_t off_from_end;
     uint8_t elem_sz;
@@ -188,31 +190,37 @@ boot_magic_off(const struct flash_area *fap)
 uint32_t
 boot_status_off(const struct flash_area *fap)
 {
-    return boot_magic_off(fap) + sizeof boot_img_magic;
+    return boot_trailer_off(fap);
 }
 
 static uint32_t
 boot_copy_done_off(const struct flash_area *fap)
 {
-    return fap->fa_size - flash_area_align(fap) * 2;
+    return fap->fa_size - BOOT_MAGIC_SZ - flash_area_align(fap) * 2;
 }
 
 static uint32_t
 boot_image_ok_off(const struct flash_area *fap)
 {
-    return fap->fa_size - flash_area_align(fap);
+    return fap->fa_size - BOOT_MAGIC_SZ - flash_area_align(fap);
+}
+
+static uint32_t
+boot_magic_off(const struct flash_area *fap)
+{
+    return fap->fa_size - BOOT_MAGIC_SZ;
 }
 
 int
 boot_read_swap_state(const struct flash_area *fap,
                      struct boot_swap_state *state)
 {
-    uint32_t magic[4];
+    uint32_t magic[BOOT_MAGIC_SZ];
     uint32_t off;
     int rc;
 
     off = boot_magic_off(fap);
-    rc = flash_area_read(fap, off, magic, sizeof magic);
+    rc = flash_area_read(fap, off, magic, BOOT_MAGIC_SZ);
     if (rc != 0) {
         return BOOT_EFLASH;
     }
@@ -297,7 +305,7 @@ boot_write_magic(const struct flash_area *fap)
 
     off = boot_magic_off(fap);
 
-    rc = flash_area_write(fap, off, boot_img_magic, sizeof boot_img_magic);
+    rc = flash_area_write(fap, off, boot_img_magic, BOOT_MAGIC_SZ);
     if (rc != 0) {
         return BOOT_EFLASH;
     }

--- a/sim/src/c.rs
+++ b/sim/src/c.rs
@@ -33,6 +33,10 @@ pub fn set_sim_flash_align(align: u8) {
     unsafe { raw::sim_flash_align = align };
 }
 
+pub fn boot_magic_sz() -> u32 {
+    unsafe { raw::BOOT_MAGIC_SZ }
+}
+
 mod raw {
     use area::CAreaDesc;
     use libc;
@@ -46,5 +50,7 @@ mod raw {
 
         pub static mut sim_flash_align: u8;
         pub fn boot_trailer_sz(min_write_sz: u8) -> u32;
+
+        pub static mut BOOT_MAGIC_SZ: u32;
     }
 }

--- a/sim/src/main.rs
+++ b/sim/src/main.rs
@@ -218,11 +218,10 @@ impl RunStatus {
 
         // Set an alignment, and position the magic value.
         c::set_sim_flash_align(align);
-        let trailer_size = c::boot_trailer_sz();
 
         // Mark the upgrade as ready to install.  (This looks like it might be a bug in the code,
         // however.)
-        mark_upgrade(&mut flash, scratch_base - trailer_size as usize);
+        mark_upgrade(&mut flash, scratch_base - c::boot_magic_sz() as usize);
 
         let (fl2, total_count) = try_upgrade(&flash, &areadesc, None);
         info!("First boot, count={}", total_count);
@@ -349,7 +348,8 @@ fn try_norevert(flash: &Flash, areadesc: &AreaDesc) -> Flash {
     // Write boot_ok
     let ok = [1u8, 0, 0, 0, 0, 0, 0, 0];
     let (slot0_base, slot0_len) = areadesc.find(FlashId::Image0);
-    fl.write(slot0_base + slot0_len - align, &ok[..align]).unwrap();
+    fl.write(slot0_base + slot0_len - align - c::boot_magic_sz() as usize,
+             &ok[..align]).unwrap();
     assert_eq!(c::boot_go(&mut fl, &areadesc), 0);
     fl
 }


### PR DESCRIPTION
DO NOT MERGE.

This is an experiment on putting the trailer magic at the end. Solves issues with copy but doesn't solve random resets. WIP.