### PR TITLE
Update to status management

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -286,12 +286,8 @@ boot_read_swap_state_by_id(int flash_area_id, struct boot_swap_state *state)
     }
 
     rc = boot_read_swap_state(fap, state);
-    if (rc) {
-        flash_area_close(fap);
-        return rc;
-    }
-
-    return 0;
+    flash_area_close(fap);
+    return rc;
 }
 
 int

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -376,7 +376,7 @@ boot_swap_type(void)
              table->bsw_image_ok_slot0  == state_slot0.image_ok)        &&
             (table->bsw_image_ok_slot1  == 0    ||
              table->bsw_image_ok_slot1  == state_slot1.image_ok)) {
-            BOOT_LOG_INF("Swap type: %s\n",
+            BOOT_LOG_INF("Swap type: %s",
                    table->bsw_swap_type == BOOT_SWAP_TYPE_NONE   ? "none"   :
                    table->bsw_swap_type == BOOT_SWAP_TYPE_TEST   ? "test"   :
                    table->bsw_swap_type == BOOT_SWAP_TYPE_PERM   ? "perm"   :

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -166,16 +166,18 @@ uint32_t
 boot_slots_trailer_sz(uint8_t min_write_sz)
 {
     return BOOT_MAGIC_SZ                                                    +
+           /* state for all sectors */
            BOOT_STATUS_MAX_ENTRIES * BOOT_STATUS_STATE_COUNT * min_write_sz +
+           /* copy_done + image_ok */
            min_write_sz * 2;
 }
 
 static uint32_t
 boot_scratch_trailer_sz(uint8_t min_write_sz)
 {
-    return BOOT_MAGIC_SZ                           +
-           BOOT_STATUS_STATE_COUNT * min_write_sz  +
-           min_write_sz * 2;
+    return BOOT_MAGIC_SZ                          +  /* magic */
+           BOOT_STATUS_STATE_COUNT * min_write_sz +  /* state for one sector */
+           min_write_sz;                             /* image_ok */
 }
 
 static uint32_t
@@ -205,6 +207,7 @@ boot_status_off(const struct flash_area *fap)
 static uint32_t
 boot_copy_done_off(const struct flash_area *fap)
 {
+    assert(fap->fa_id != FLASH_AREA_IMAGE_SCRATCH);
     return fap->fa_size - flash_area_align(fap) * 2;
 }
 
@@ -229,10 +232,12 @@ boot_read_swap_state(const struct flash_area *fap,
     }
     state->magic = boot_magic_code(magic);
 
-    off = boot_copy_done_off(fap);
-    rc = flash_area_read(fap, off, &state->copy_done, 1);
-    if (rc != 0) {
-        return BOOT_EFLASH;
+    if (fap->fa_id != FLASH_AREA_IMAGE_SCRATCH) {
+        off = boot_copy_done_off(fap);
+        rc = flash_area_read(fap, off, &state->copy_done, 1);
+        if (rc != 0) {
+            return BOOT_EFLASH;
+        }
     }
 
     off = boot_image_ok_off(fap);
@@ -248,56 +253,31 @@ boot_read_swap_state(const struct flash_area *fap,
  * Reads the image trailer from the scratch area.
  */
 int
-boot_read_swap_state_scratch(struct boot_swap_state *state)
+boot_read_swap_state_by_id(int flash_area_id, struct boot_swap_state *state)
 {
     const struct flash_area *fap;
     int rc;
 
-    rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &fap);
+    switch (flash_area_id) {
+    case FLASH_AREA_IMAGE_SCRATCH:
+    case FLASH_AREA_IMAGE_0:
+    case FLASH_AREA_IMAGE_1:
+        rc = flash_area_open(flash_area_id, &fap);
+        if (rc != 0) {
+            return BOOT_EFLASH;
+        }
+        break;
+    default:
+        return BOOT_EFLASH;
+    }
+
+    rc = boot_read_swap_state(fap, state);
     if (rc) {
-        rc = BOOT_EFLASH;
-        goto done;
+        flash_area_close(fap);
+        return rc;
     }
 
-    rc = boot_read_swap_state(fap, state);
-    if (rc != 0) {
-        goto done;
-    }
-
-    rc = 0;
-
-done:
-    flash_area_close(fap);
-    return rc;
-}
-
-/**
- * Reads the image trailer from a given image slot.
- */
-int
-boot_read_swap_state_img(int slot, struct boot_swap_state *state)
-{
-    const struct flash_area *fap;
-    int area_id;
-    int rc;
-
-    area_id = flash_area_id_from_image_slot(slot);
-    rc = flash_area_open(area_id, &fap);
-    if (rc != 0) {
-        rc = BOOT_EFLASH;
-        goto done;
-    }
-
-    rc = boot_read_swap_state(fap, state);
-    if (rc != 0) {
-        goto done;
-    }
-
-    rc = 0;
-
-done:
-    flash_area_close(fap);
-    return rc;
+    return 0;
 }
 
 int
@@ -316,15 +296,24 @@ boot_write_magic(const struct flash_area *fap)
     return 0;
 }
 
-int
-boot_write_copy_done(const struct flash_area *fap)
+static int
+boot_write_flag(int flag, const struct flash_area *fap)
 {
     uint32_t off;
     int rc;
     uint8_t buf[BOOT_MAX_ALIGN];
     uint8_t align;
 
-    off = boot_copy_done_off(fap);
+    switch (flag) {
+    case BOOT_FLAG_COPY_DONE:
+        off = boot_copy_done_off(fap);
+        break;
+    case BOOT_FLAG_IMAGE_OK:
+        off = boot_image_ok_off(fap);
+        break;
+    default:
+        return BOOT_EFLASH;
+    }
 
     align = hal_flash_align(fap->fa_device_id);
     assert(align <= BOOT_MAX_ALIGN);
@@ -340,26 +329,15 @@ boot_write_copy_done(const struct flash_area *fap)
 }
 
 int
+boot_write_copy_done(const struct flash_area *fap)
+{
+    return boot_write_flag(BOOT_FLAG_COPY_DONE, fap);
+}
+
+int
 boot_write_image_ok(const struct flash_area *fap)
 {
-    uint32_t off;
-    int rc;
-    uint8_t buf[BOOT_MAX_ALIGN];
-    uint8_t align;
-
-    off = boot_image_ok_off(fap);
-
-    align = hal_flash_align(fap->fa_device_id);
-    assert(align <= BOOT_MAX_ALIGN);
-    memset(buf, 0xFF, BOOT_MAX_ALIGN);
-    buf[0] = 1;
-
-    rc = flash_area_write(fap, off, buf, align);
-    if (rc != 0) {
-        return BOOT_EFLASH;
-    }
-
-    return 0;
+    return boot_write_flag(BOOT_FLAG_IMAGE_OK, fap);
 }
 
 int
@@ -371,10 +349,10 @@ boot_swap_type(void)
     int rc;
     int i;
 
-    rc = boot_read_swap_state_img(0, &state_slot0);
+    rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_0, &state_slot0);
     assert(rc == 0);
 
-    rc = boot_read_swap_state_img(1, &state_slot1);
+    rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_1, &state_slot1);
     assert(rc == 0);
 
     for (i = 0; i < BOOT_SWAP_TABLES_COUNT; i++) {
@@ -419,10 +397,9 @@ boot_set_pending(int permanent)
 {
     const struct flash_area *fap;
     struct boot_swap_state state_slot1;
-    int area_id;
     int rc;
 
-    rc = boot_read_swap_state_img(1, &state_slot1);
+    rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_1, &state_slot1);
     if (rc != 0) {
         return rc;
     }
@@ -433,8 +410,7 @@ boot_set_pending(int permanent)
         return 0;
 
     case BOOT_MAGIC_UNSET:
-        area_id = flash_area_id_from_image_slot(1);
-        rc = flash_area_open(area_id, &fap);
+        rc = flash_area_open(FLASH_AREA_IMAGE_1, &fap);
         if (rc != 0) {
             rc = BOOT_EFLASH;
         } else {
@@ -467,7 +443,7 @@ boot_set_confirmed(void)
     struct boot_swap_state state_slot0;
     int rc;
 
-    rc = boot_read_swap_state_img(0, &state_slot0);
+    rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_0, &state_slot0);
     if (rc != 0) {
         return rc;
     }

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -198,6 +198,20 @@ boot_magic_off(const struct flash_area *fap)
     return fap->fa_size - off_from_end;
 }
 
+int
+boot_status_entries(const struct flash_area *fap)
+{
+    switch (fap->fa_id) {
+    case FLASH_AREA_IMAGE_0:
+    case FLASH_AREA_IMAGE_1:
+        return BOOT_STATUS_STATE_COUNT * BOOT_STATUS_MAX_ENTRIES;
+    case FLASH_AREA_IMAGE_SCRATCH:
+        return BOOT_STATUS_STATE_COUNT;
+    default:
+        return BOOT_EBADARGS;
+    }
+}
+
 uint32_t
 boot_status_off(const struct flash_area *fap)
 {

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -328,7 +328,7 @@ boot_write_flag(int flag, const struct flash_area *fap)
     align = hal_flash_align(fap->fa_device_id);
     assert(align <= BOOT_MAX_ALIGN);
     memset(buf, 0xFF, BOOT_MAX_ALIGN);
-    buf[0] = 1;
+    buf[0] = BOOT_FLAG_SET;
 
     rc = flash_area_write(fap, off, buf, align);
     if (rc != 0) {
@@ -472,12 +472,12 @@ boot_set_confirmed(void)
         return BOOT_EBADVECT;
     }
 
-    if (state_slot0.copy_done == 0xff) {
+    if (state_slot0.copy_done == BOOT_FLAG_UNSET) {
         /* Swap never completed.  This is unexpected. */
         return BOOT_EBADVECT;
     }
 
-    if (state_slot0.image_ok != BOOT_IMAGE_UNSET) {
+    if (state_slot0.image_ok != BOOT_FLAG_UNSET) {
         /* Already confirmed. */
         return 0;
     }

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -282,7 +282,7 @@ boot_read_swap_state_by_id(int flash_area_id, struct boot_swap_state *state)
         }
         break;
     default:
-        return BOOT_EFLASH;
+        return BOOT_EBADARGS;
     }
 
     rc = boot_read_swap_state(fap, state);
@@ -326,7 +326,7 @@ boot_write_flag(int flag, const struct flash_area *fap)
         off = boot_image_ok_off(fap);
         break;
     default:
-        return BOOT_EFLASH;
+        return BOOT_EBADARGS;
     }
 
     align = hal_flash_align(fap->fa_device_id);

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -467,7 +467,7 @@ boot_set_confirmed(void)
         return BOOT_EBADVECT;
     }
 
-    if (state_slot0.image_ok != 0xff) {
+    if (state_slot0.image_ok != BOOT_IMAGE_UNSET) {
         /* Already confirmed. */
         return 0;
     }

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -90,6 +90,9 @@ struct boot_swap_state {
 #define BOOT_FLAG_IMAGE_OK         0
 #define BOOT_FLAG_COPY_DONE        1
 
+#define BOOT_IMAGE_OK              0x01
+#define BOOT_IMAGE_UNSET           0xff
+
 extern const uint32_t BOOT_MAGIC_SZ;
 
 int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, int slen,

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -90,8 +90,8 @@ struct boot_swap_state {
 #define BOOT_FLAG_IMAGE_OK         0
 #define BOOT_FLAG_COPY_DONE        1
 
-#define BOOT_IMAGE_OK              0x01
-#define BOOT_IMAGE_UNSET           0xff
+#define BOOT_FLAG_SET              0x01
+#define BOOT_FLAG_UNSET            0xff
 
 extern const uint32_t BOOT_MAGIC_SZ;
 

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -99,6 +99,7 @@ int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, int slen,
     uint8_t key_id);
 
 uint32_t boot_slots_trailer_sz(uint8_t min_write_sz);
+int boot_status_entries(const struct flash_area *fap);
 uint32_t boot_status_off(const struct flash_area *fap);
 int boot_read_swap_state(const struct flash_area *fap,
                          struct boot_swap_state *state);

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -86,10 +86,12 @@ struct boot_swap_state {
 #define BOOT_STATUS_SOURCE_SCRATCH 1
 #define BOOT_STATUS_SOURCE_SLOT0   2
 
+extern const uint32_t BOOT_MAGIC_SZ;
+
 int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, int slen,
     uint8_t key_id);
 
-uint32_t boot_trailer_sz(uint8_t min_write_sz);
+uint32_t boot_slots_trailer_sz(uint8_t min_write_sz);
 uint32_t boot_status_off(const struct flash_area *fap);
 int boot_read_swap_state(const struct flash_area *fap,
                          struct boot_swap_state *state);
@@ -100,8 +102,6 @@ int boot_write_status(struct boot_status *bs);
 int boot_schedule_test_swap(void);
 int boot_write_copy_done(const struct flash_area *fap);
 int boot_write_image_ok(const struct flash_area *fap);
-
-uint32_t boot_status_sz(uint8_t min_write_sz);
 
 #ifdef __cplusplus
 }

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -45,8 +45,9 @@ struct flash_area;
  * Maintain state of copy progress.
  */
 struct boot_status {
-    uint32_t idx;       /* Which area we're operating on */
-    uint8_t state;      /* Which part of the swapping process are we at */
+    uint32_t idx;         /* Which area we're operating on */
+    uint8_t state;        /* Which part of the swapping process are we at */
+    uint8_t use_scratch;  /* Are status bytes ever written to scratch? */
 };
 
 #define BOOT_MAGIC_GOOD  1
@@ -86,6 +87,9 @@ struct boot_swap_state {
 #define BOOT_STATUS_SOURCE_SCRATCH 1
 #define BOOT_STATUS_SOURCE_SLOT0   2
 
+#define BOOT_FLAG_IMAGE_OK         0
+#define BOOT_FLAG_COPY_DONE        1
+
 extern const uint32_t BOOT_MAGIC_SZ;
 
 int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, int slen,
@@ -95,8 +99,8 @@ uint32_t boot_slots_trailer_sz(uint8_t min_write_sz);
 uint32_t boot_status_off(const struct flash_area *fap);
 int boot_read_swap_state(const struct flash_area *fap,
                          struct boot_swap_state *state);
-int boot_read_swap_state_img(int slot, struct boot_swap_state *state);
-int boot_read_swap_state_scratch(struct boot_swap_state *state);
+int boot_read_swap_state_by_id(int flash_area_id,
+                               struct boot_swap_state *state);
 int boot_write_magic(const struct flash_area *fap);
 int boot_write_status(struct boot_status *bs);
 int boot_schedule_test_swap(void);

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -413,14 +413,8 @@ boot_read_status_bytes(const struct flash_area *fap, struct boot_status *bs)
 
     if (found) {
         i--;
-        /* FIXME: is this test required? */
-        if (fap->fa_id != FLASH_AREA_IMAGE_SCRATCH) {
-            bs->idx = i / BOOT_STATUS_STATE_COUNT;
-            bs->state = i % BOOT_STATUS_STATE_COUNT;
-        } else {
-            bs->idx = 0;
-            bs->state = i;
-        }
+        bs->idx = i / BOOT_STATUS_STATE_COUNT;
+        bs->state = i % BOOT_STATUS_STATE_COUNT;
     }
 
     return 0;
@@ -931,7 +925,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
                               0, img_off, copy_sz);
         assert(rc == 0);
 
-        if (bs->idx == 0 && bs->use_scratch) {
+        if (bs->use_scratch) {
             rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &fap);
             assert(rc == 0);
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -393,11 +393,7 @@ boot_read_status_bytes(const struct flash_area *fap, struct boot_status *bs)
     int i;
 
     off = boot_status_off(fap);
-
-    max_entries = BOOT_STATUS_STATE_COUNT;
-    if (fap->fa_id != FLASH_AREA_IMAGE_SCRATCH) {
-        max_entries *= BOOT_STATUS_MAX_ENTRIES;
-    }
+    max_entries = boot_status_entries(fap);
 
     found = 0;
     for (i = 0; i < max_entries; i++) {

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -858,8 +858,17 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
               boot_data.imgs[0].sectors[0].fa_off;
 
     copy_sz = sz;
-
     trailer_sz = boot_slots_trailer_sz(boot_data.write_sz);
+
+    /* sz in this function is always is always sized on a multiple of the
+     * sector size. The check against the first address of the last sector
+     * is to determine if we're swapping the last sector. The last sector
+     * needs special handling because it's where the trailer lives. If we're
+     * copying it, we need to use scratch to write the trailer temporarily.
+     *
+     * NOTE: `use_scratch` is a temporary flag (never written to flash) which
+     * controls if special handling is needed (swapping last sector).
+     */
     if (boot_data.imgs[0].sectors[idx].fa_off + sz >
         boot_data.imgs[0].sectors[boot_data.imgs[0].num_sectors - 1].fa_off) {
         copy_sz -= trailer_sz;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -788,7 +788,7 @@ boot_status_init_by_id(int flash_area_id)
     rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_1, &swap_state);
     assert(rc == 0);
 
-    if (swap_state.image_ok == BOOT_IMAGE_OK) {
+    if (swap_state.image_ok == BOOT_FLAG_SET) {
         rc = boot_write_image_ok(fap);
         assert(rc == 0);
     }
@@ -947,7 +947,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
                                             &swap_state);
             assert(rc == 0);
 
-            if (swap_state.image_ok == BOOT_IMAGE_OK) {
+            if (swap_state.image_ok == BOOT_FLAG_SET) {
                 rc = boot_write_image_ok(fap);
                 assert(rc == 0);
             }
@@ -1138,14 +1138,14 @@ boot_finalize_revert_swap(void)
         }
     }
 
-    if (state_slot0.copy_done == 0xff) {
+    if (state_slot0.copy_done == BOOT_FLAG_UNSET) {
         rc = boot_write_copy_done(fap);
         if (rc != 0) {
             return rc;
         }
     }
 
-    if (state_slot0.image_ok == BOOT_IMAGE_UNSET) {
+    if (state_slot0.image_ok == BOOT_FLAG_UNSET) {
         rc = boot_write_image_ok(fap);
         if (rc != 0) {
             return rc;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -798,7 +798,7 @@ boot_status_init_by_id(int flash_area_id)
     rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_1, &swap_state);
     assert(rc == 0);
 
-    if (swap_state.image_ok == 0x01) {
+    if (swap_state.image_ok == BOOT_IMAGE_OK) {
         rc = boot_write_image_ok(fap);
         assert(rc == 0);
     }
@@ -957,7 +957,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
                                             &swap_state);
             assert(rc == 0);
 
-            if (swap_state.image_ok == 0x01) {
+            if (swap_state.image_ok == BOOT_IMAGE_OK) {
                 rc = boot_write_image_ok(fap);
                 assert(rc == 0);
             }
@@ -1155,7 +1155,7 @@ boot_finalize_revert_swap(void)
         }
     }
 
-    if (state_slot0.image_ok == 0xff) {
+    if (state_slot0.image_ok == BOOT_IMAGE_UNSET) {
         rc = boot_write_image_ok(fap);
         if (rc != 0) {
             return rc;

--- a/sim/src/c.rs
+++ b/sim/src/c.rs
@@ -22,7 +22,7 @@ pub fn set_flash_counter(counter: i32) {
 }
 
 pub fn boot_trailer_sz() -> u32 {
-    unsafe { raw::boot_trailer_sz(raw::sim_flash_align) }
+    unsafe { raw::boot_slots_trailer_sz(raw::sim_flash_align) }
 }
 
 pub fn get_sim_flash_align() -> u8 {
@@ -45,6 +45,6 @@ mod raw {
         pub static mut flash_counter: libc::c_int;
 
         pub static mut sim_flash_align: u8;
-        pub fn boot_trailer_sz(min_write_sz: u8) -> u32;
+        pub fn boot_slots_trailer_sz(min_write_sz: u8) -> u32;
     }
 }


### PR DESCRIPTION
PLEASE DO NOT MERGE.

Trailer management, most importantly status, is now handled separately
from image sectors handling. This should fix issues with resets that
happen while doing a swap.