### PR TITLE
[RFC, DO NOT MERGE] Flash map fixups

### DIFF
--- a/apps/boot/src/boot.c
+++ b/apps/boot/src/boot.c
@@ -47,6 +47,7 @@ int
 main(void)
 {
     struct boot_rsp rsp;
+    uint32_t flash_base;
     int rc;
 
 #if MYNEWT_VAL(BOOT_SERIAL)
@@ -70,7 +71,11 @@ main(void)
     rc = boot_go(&rsp);
     assert(rc == 0);
 
-    hal_system_start((void *)(rsp.br_image_off + rsp.br_hdr->ih_hdr_size));
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    assert(rc == 0);
+
+    hal_system_start((void *)(flash_base + rsp.br_image_off +
+                              rsp.br_hdr->ih_hdr_size));
 
     return 0;
 }

--- a/apps/boot/src/boot.c
+++ b/apps/boot/src/boot.c
@@ -70,7 +70,7 @@ main(void)
     rc = boot_go(&rsp);
     assert(rc == 0);
 
-    hal_system_start((void *)(rsp.br_image_addr + rsp.br_hdr->ih_hdr_size));
+    hal_system_start((void *)(rsp.br_image_off + rsp.br_hdr->ih_hdr_size));
 
     return 0;
 }

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -51,10 +51,10 @@ struct boot_rsp {
 
     /**
      * The flash offset of the image to execute.  Indicates the position of
-     * the image header.
+     * the image header within its flash device.
      */
     uint8_t br_flash_id;
-    uint32_t br_image_addr;
+    uint32_t br_image_off;
 };
 
 /* you must have pre-allocated all the entries within this structure */

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -53,7 +53,7 @@ struct boot_rsp {
      * The flash offset of the image to execute.  Indicates the position of
      * the image header within its flash device.
      */
-    uint8_t br_flash_id;
+    uint8_t br_flash_dev_id;
     uint32_t br_image_off;
 };
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1104,7 +1104,7 @@ boot_go(struct boot_rsp *rsp)
     }
 
     /* Always boot from the primary slot. */
-    rsp->br_flash_id = boot_data.imgs[0].area->fa_device_id;
+    rsp->br_flash_dev_id = boot_data.imgs[0].area->fa_device_id;
     rsp->br_image_off = boot_data.imgs[0].area->fa_off;
     rsp->br_hdr = &boot_data.imgs[slot].hdr;
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1105,7 +1105,7 @@ boot_go(struct boot_rsp *rsp)
 
     /* Always boot from the primary slot. */
     rsp->br_flash_id = boot_data.imgs[0].area->fa_device_id;
-    rsp->br_image_addr = boot_data.imgs[0].area->fa_off;
+    rsp->br_image_off = boot_data.imgs[0].area->fa_off;
     rsp->br_hdr = &boot_data.imgs[slot].hdr;
 
  out_close:

--- a/boot/bootutil/test/src/boot_test_utils.c
+++ b/boot/bootutil/test/src/boot_test_utils.c
@@ -505,7 +505,7 @@ boot_test_util_verify_all(int expected_swap_type,
 
         TEST_ASSERT(memcmp(rsp.br_hdr, slot0hdr, sizeof *slot0hdr) == 0);
         TEST_ASSERT(rsp.br_flash_id == boot_test_img_addrs[0].flash_id);
-        TEST_ASSERT(rsp.br_image_addr == boot_test_img_addrs[0].address);
+        TEST_ASSERT(rsp.br_image_off == boot_test_img_addrs[0].address);
 
         boot_test_util_verify_flash(slot0hdr, orig_slot_0,
                                     slot1hdr, orig_slot_1);

--- a/boot/bootutil/test/src/boot_test_utils.c
+++ b/boot/bootutil/test/src/boot_test_utils.c
@@ -464,6 +464,7 @@ boot_test_util_verify_all(int expected_swap_type,
     const struct image_header *slot0hdr;
     const struct image_header *slot1hdr;
     struct boot_rsp rsp;
+    uint32_t flash_base;
     int orig_slot_0;
     int orig_slot_1;
     int num_swaps;
@@ -503,9 +504,13 @@ boot_test_util_verify_all(int expected_swap_type,
             orig_slot_1 = 0;
         }
 
+        rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+        TEST_ASSERT_FATAL(rc == 0);
+
         TEST_ASSERT(memcmp(rsp.br_hdr, slot0hdr, sizeof *slot0hdr) == 0);
         TEST_ASSERT(rsp.br_flash_dev_id == boot_test_img_addrs[0].flash_id);
-        TEST_ASSERT(rsp.br_image_off == boot_test_img_addrs[0].address);
+        TEST_ASSERT(flash_base + rsp.br_image_off ==
+                    boot_test_img_addrs[0].address);
 
         boot_test_util_verify_flash(slot0hdr, orig_slot_0,
                                     slot1hdr, orig_slot_1);

--- a/boot/bootutil/test/src/boot_test_utils.c
+++ b/boot/bootutil/test/src/boot_test_utils.c
@@ -504,7 +504,7 @@ boot_test_util_verify_all(int expected_swap_type,
         }
 
         TEST_ASSERT(memcmp(rsp.br_hdr, slot0hdr, sizeof *slot0hdr) == 0);
-        TEST_ASSERT(rsp.br_flash_id == boot_test_img_addrs[0].flash_id);
+        TEST_ASSERT(rsp.br_flash_dev_id == boot_test_img_addrs[0].flash_id);
         TEST_ASSERT(rsp.br_image_off == boot_test_img_addrs[0].address);
 
         boot_test_util_verify_flash(slot0hdr, orig_slot_0,

--- a/boot/zephyr/flash_map.c
+++ b/boot/zephyr/flash_map.c
@@ -32,26 +32,49 @@
 extern struct device *boot_flash_device;
 
 /*
+ * For now, we only support one flash device.
+ *
+ * Pick a random device ID for it that's unlikely to collide with
+ * anything "real".
+ */
+#define FLASH_DEVICE_ID 100
+#define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
+
+/*
  * The flash area describes essentially the partition table of the
  * flash.  In this case, it starts with FLASH_AREA_IMAGE_0.
  */
 static const struct flash_area part_map[] = {
     {
         .fa_id = FLASH_AREA_IMAGE_0,
+        .fa_device_id = FLASH_DEVICE_ID,
         .fa_off = FLASH_AREA_IMAGE_0_OFFSET,
         .fa_size = FLASH_AREA_IMAGE_0_SIZE,
     },
     {
         .fa_id = FLASH_AREA_IMAGE_1,
+        .fa_device_id = FLASH_DEVICE_ID,
         .fa_off = FLASH_AREA_IMAGE_1_OFFSET,
         .fa_size = FLASH_AREA_IMAGE_1_SIZE,
     },
     {
         .fa_id = FLASH_AREA_IMAGE_SCRATCH,
+        .fa_device_id = FLASH_DEVICE_ID,
         .fa_off = FLASH_AREA_IMAGE_SCRATCH_OFFSET,
         .fa_size = FLASH_AREA_IMAGE_SCRATCH_SIZE,
     },
 };
+
+int flash_device_base(uint8_t fd_id, uint32_t *ret)
+{
+    if (fd_id != FLASH_DEVICE_ID) {
+        BOOT_LOG_ERR("invalid flash ID %d; expected %d",
+                     fd_id, FLASH_DEVICE_ID);
+        return -EINVAL;
+    }
+    *ret = FLASH_DEVICE_BASE;
+    return 0;
+}
 
 /*
  * `open` a flash area.  The `area` in this case is not the individual

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -75,6 +75,25 @@ struct flash_area {
     uint32_t fa_size;
 };
 
+/**
+ * @brief Structure describing a sector within a flash area.
+ *
+ * Each sector has an offset relative to the start of its flash area
+ * (NOT relative to the start of its flash device), and a size. A
+ * flash area may contain sectors with different sizes.
+ */
+struct flash_sector {
+    /**
+     * Offset of this sector, from the start of its flash area (not device).
+     */
+    uint32_t fs_off;
+
+    /**
+     * Size of this sector, in bytes.
+     */
+    uint32_t fs_size;
+};
+
 /*
  * Retrieve a memory-mapped flash device's base address.
  *
@@ -104,8 +123,16 @@ int flash_area_erase(const struct flash_area *, uint32_t off, uint32_t len);
 uint8_t flash_area_align(const struct flash_area *);
 
 /*
- * Given flash map index, return info about sectors within the area.
+ * Given flash area ID, return info about sectors within the area.
  */
+int flash_area_get_sectors(int fa_id, uint32_t *count,
+  struct flash_sector *sectors);
+
+/*
+ * Similar to flash_area_get_sectors(), but return the values in an
+ * array of struct flash_area instead.
+ */
+__attribute__((deprecated))
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);
 
 int flash_area_id_from_image_slot(int slot);

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -43,11 +43,35 @@ extern "C" {
  */
 #include <inttypes.h>
 
+/**
+ * @brief Structure describing an area on a flash device.
+ *
+ * Multiple flash devices may be available in the system, each of
+ * which may have its own areas. For this reason, flash areas track
+ * which flash device they are part of.
+ */
 struct flash_area {
+    /**
+     * This flash area's ID; unique in the system.
+     */
     uint8_t fa_id;
+
+    /**
+     * ID of the flash device this area is a part of.
+     */
     uint8_t fa_device_id;
+
     uint16_t pad16;
+
+    /**
+     * This area's offset, relative to the beginning of its flash
+     * device's storage.
+     */
     uint32_t fa_off;
+
+    /**
+     * This area's size, in bytes.
+     */
     uint32_t fa_size;
 };
 

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -76,6 +76,13 @@ struct flash_area {
 };
 
 /*
+ * Retrieve a memory-mapped flash device's base address.
+ *
+ * Returns 0 on success, or an error code on failure.
+ */
+int flash_device_base(uint8_t fd_id, uint32_t *ret);
+
+/*
  * Start using flash area.
  */
 int flash_area_open(uint8_t id, const struct flash_area **);

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <assert.h>
 #include <zephyr.h>
 #include <flash.h>
 #include <asm_inline.h>
@@ -25,6 +26,7 @@
 #include "bootutil/bootutil_log.h"
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"
+#include "flash_map/flash_map.h"
 
 struct device *boot_flash_device;
 
@@ -39,13 +41,19 @@ struct arm_vector_table {
 static void do_boot(struct boot_rsp *rsp)
 {
     struct arm_vector_table *vt;
+    uint32_t flash_base;
+    int rc;
 
     /* The beginning of the image is the ARM vector table, containing
      * the initial stack pointer address and the reset vector
      * consecutively. Manually set the stack pointer and jump into the
      * reset vector
      */
-    vt = (struct arm_vector_table *)(rsp->br_image_off +
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    assert(rc == 0);
+
+    vt = (struct arm_vector_table *)(flash_base +
+                                     rsp->br_image_off +
                                      rsp->br_hdr->ih_hdr_size);
     irq_lock();
     sys_clock_disable();
@@ -59,9 +67,15 @@ static void do_boot(struct boot_rsp *rsp)
  */
 static void do_boot(struct boot_rsp *rsp)
 {
+    uint32_t flash_base;
     void *start;
+    int rc;
 
-    start = (void *)(rsp->br_image_off + rsp->br_hdr->ih_hdr_size);
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    assert(rc == 0);
+
+    start = (void *)(flash_base + rsp->br_image_off +
+                     rsp->br_hdr->ih_hdr_size);
 
     /* Lock interrupts and dive into the entry point */
     irq_lock();

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -45,7 +45,7 @@ static void do_boot(struct boot_rsp *rsp)
      * consecutively. Manually set the stack pointer and jump into the
      * reset vector
      */
-    vt = (struct arm_vector_table *)(rsp->br_image_addr +
+    vt = (struct arm_vector_table *)(rsp->br_image_off +
                                      rsp->br_hdr->ih_hdr_size);
     irq_lock();
     sys_clock_disable();
@@ -61,7 +61,7 @@ static void do_boot(struct boot_rsp *rsp)
 {
     void *start;
 
-    start = (void *)(rsp->br_image_addr + rsp->br_hdr->ih_hdr_size);
+    start = (void *)(rsp->br_image_off + rsp->br_hdr->ih_hdr_size);
 
     /* Lock interrupts and dive into the entry point */
     irq_lock();
@@ -92,7 +92,7 @@ void main(void)
             ;
     }
 
-    BOOT_LOG_INF("Bootloader chainload address: 0x%x", rsp.br_image_addr);
+    BOOT_LOG_INF("Bootloader chainload address offset: 0x%x", rsp.br_image_off);
     BOOT_LOG_INF("Jumping to the first image slot");
     do_boot(&rsp);
 


### PR DESCRIPTION
There's a bug in boot_go() and its users, which assume that the image offset is equal to its address. This will break with 96b_carbon on recent Zephyr builds, which are using an MPU to make sure that flash addresses use the base at 0x08000000 rather than relying on aliasing at 0x0.

This RFC series adds flash_device_base() to flash_map.h to allow fixing that, and makes other improvements to the API which clarify its usage and save memory (this file is annoying to change since there are multiple versions and implementations, but while we're here, we might as well).

It's not ready to merge; while I verified that I could swap an image on 96b_nitrogen (not Carbon as there are other MPU-related issues to debug as well), there are bugs, the simulator isn't updated, we'd need to propagate changes to the mynewt-core version of flash_map.h, etc.

I'm posting it in hopes of getting some feedback about the approach. If it's welcomed, I'll polish it up for a "real" PR.