### PR TITLE
MCUB-54

### DIFF
--- a/apps/boot/src/boot.c
+++ b/apps/boot/src/boot.c
@@ -47,6 +47,7 @@ int
 main(void)
 {
     struct boot_rsp rsp;
+    uintptr_t flash_base;
     int rc;
 
 #if MYNEWT_VAL(BOOT_SERIAL)
@@ -70,7 +71,11 @@ main(void)
     rc = boot_go(&rsp);
     assert(rc == 0);
 
-    hal_system_start((void *)(rsp.br_image_off + rsp.br_hdr->ih_hdr_size));
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    assert(rc == 0);
+
+    hal_system_start((void *)(flash_base + rsp.br_image_off +
+                              rsp.br_hdr->ih_hdr_size));
 
     return 0;
 }

--- a/apps/boot/src/boot.c
+++ b/apps/boot/src/boot.c
@@ -70,7 +70,7 @@ main(void)
     rc = boot_go(&rsp);
     assert(rc == 0);
 
-    hal_system_start((void *)(rsp.br_image_addr + rsp.br_hdr->ih_hdr_size));
+    hal_system_start((void *)(rsp.br_image_off + rsp.br_hdr->ih_hdr_size));
 
     return 0;
 }

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -51,10 +51,10 @@ struct boot_rsp {
 
     /**
      * The flash offset of the image to execute.  Indicates the position of
-     * the image header.
+     * the image header within its flash device.
      */
     uint8_t br_flash_id;
-    uint32_t br_image_addr;
+    uint32_t br_image_off;
 };
 
 /* you must have pre-allocated all the entries within this structure */

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -53,7 +53,7 @@ struct boot_rsp {
      * The flash offset of the image to execute.  Indicates the position of
      * the image header within its flash device.
      */
-    uint8_t br_flash_id;
+    uint8_t br_flash_dev_id;
     uint32_t br_image_off;
 };
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1107,7 +1107,7 @@ boot_go(struct boot_rsp *rsp)
     }
 
     /* Always boot from the primary slot. */
-    rsp->br_flash_id = boot_data.imgs[0].area->fa_device_id;
+    rsp->br_flash_dev_id = boot_data.imgs[0].area->fa_device_id;
     rsp->br_image_off = boot_data.imgs[0].area->fa_off;
     rsp->br_hdr = &boot_data.imgs[slot].hdr;
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1108,7 +1108,7 @@ boot_go(struct boot_rsp *rsp)
 
     /* Always boot from the primary slot. */
     rsp->br_flash_id = boot_data.imgs[0].area->fa_device_id;
-    rsp->br_image_addr = boot_data.imgs[0].area->fa_off;
+    rsp->br_image_off = boot_data.imgs[0].area->fa_off;
     rsp->br_hdr = &boot_data.imgs[slot].hdr;
 
  out:

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -232,7 +232,7 @@ boot_previous_swap_type(void)
             return boot_swap_trans_table[i][0];
         }
     }
-    
+
     /* XXX: Temporary assert. */
     assert(0);
 
@@ -571,7 +571,7 @@ boot_validate_slot(int slot)
 {
     const struct flash_area *fap;
     int rc;
-    
+
     if (boot_data.imgs[slot].hdr.ih_magic == 0xffffffff ||
         boot_data.imgs[slot].hdr.ih_flags & IMAGE_F_NON_BOOTABLE) {
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -39,6 +39,7 @@
 #include "bootutil/bootutil_log.h"
 
 #define BOOT_MAX_IMG_SECTORS        120
+#define BOOT_MAX_SCRATCH_SECTORS    35
 
 /** Number of image slots in flash; currently limited to two. */
 #define BOOT_NUM_SLOTS              2
@@ -46,11 +47,14 @@
 static struct {
     struct {
         struct image_header hdr;
-        struct flash_area *sectors;
-        int num_sectors;
+        const struct flash_area *area;
+        struct flash_sector *sectors;
+        uint32_t num_sectors;
     } imgs[BOOT_NUM_SLOTS];
 
-    struct flash_area scratch_sector;
+    const struct flash_area *scratch_area;
+    struct flash_sector *scratch_sectors;
+    uint32_t scratch_num_sectors;
 
     uint8_t write_sz;
 } boot_data;
@@ -300,8 +304,8 @@ boot_write_sz(void)
      * on what the minimum write size is for scratch area, active image slot.
      * We need to use the bigger of those 2 values.
      */
-    elem_sz = hal_flash_align(boot_data.imgs[0].sectors[0].fa_device_id);
-    align = hal_flash_align(boot_data.scratch_sector.fa_device_id);
+    elem_sz = hal_flash_align(boot_data.imgs[0].area->fa_device_id);
+    align = hal_flash_align(boot_data.scratch_area->fa_device_id);
     if (align > elem_sz) {
         elem_sz = align;
     }
@@ -312,8 +316,8 @@ boot_write_sz(void)
 static int
 boot_slots_compatible(void)
 {
-    const struct flash_area *sector0;
-    const struct flash_area *sector1;
+    const struct flash_sector *sector0;
+    const struct flash_sector *sector1;
     int i;
 
     /* Ensure both image slots have identical sector layouts. */
@@ -323,7 +327,7 @@ boot_slots_compatible(void)
     for (i = 0; i < boot_data.imgs[0].num_sectors; i++) {
         sector0 = boot_data.imgs[0].sectors + i;
         sector1 = boot_data.imgs[1].sectors + i;
-        if (sector0->fa_size != sector1->fa_size) {
+        if (sector0->fs_size != sector1->fs_size) {
             return 0;
         }
     }
@@ -340,32 +344,34 @@ boot_slots_compatible(void)
 static int
 boot_read_sectors(void)
 {
-    const struct flash_area *scratch;
-    int num_sectors_slot0;
-    int num_sectors_slot1;
+    uint32_t num_sectors_slot0;
+    uint32_t num_sectors_slot1;
+    uint32_t num_sectors_scratch;
     int rc;
 
     num_sectors_slot0 = BOOT_MAX_IMG_SECTORS;
-    rc = flash_area_to_sectors(FLASH_AREA_IMAGE_0, &num_sectors_slot0,
-                               boot_data.imgs[0].sectors);
+    rc = flash_area_get_sectors(FLASH_AREA_IMAGE_0, &num_sectors_slot0,
+                                boot_data.imgs[0].sectors);
     if (rc != 0) {
         return BOOT_EFLASH;
     }
     boot_data.imgs[0].num_sectors = num_sectors_slot0;
 
     num_sectors_slot1 = BOOT_MAX_IMG_SECTORS;
-    rc = flash_area_to_sectors(FLASH_AREA_IMAGE_1, &num_sectors_slot1,
-                               boot_data.imgs[1].sectors);
+    rc = flash_area_get_sectors(FLASH_AREA_IMAGE_1, &num_sectors_slot1,
+                                boot_data.imgs[1].sectors);
     if (rc != 0) {
         return BOOT_EFLASH;
     }
     boot_data.imgs[1].num_sectors = num_sectors_slot1;
 
-    rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &scratch);
+    num_sectors_scratch = BOOT_MAX_SCRATCH_SECTORS;
+    rc = flash_area_get_sectors(FLASH_AREA_IMAGE_SCRATCH, &num_sectors_scratch,
+                                boot_data.scratch_sectors);
     if (rc != 0) {
         return BOOT_EFLASH;
     }
-    boot_data.scratch_sector = *scratch;
+    boot_data.scratch_num_sectors = num_sectors_scratch;
 
     boot_data.write_sz = boot_write_sz();
 
@@ -654,8 +660,8 @@ boot_copy_sz(int last_sector_idx, int *out_first_sector_idx)
     sz = 0;
 
     for (i = last_sector_idx; i >= 0; i--) {
-        new_sz = sz + boot_data.imgs[0].sectors[i].fa_size;
-        if (new_sz > boot_data.scratch_sector.fa_size) {
+        new_sz = sz + boot_data.imgs[0].sectors[i].fs_size;
+        if (new_sz > boot_data.scratch_area->fa_size) {
             break;
         }
         sz = new_sz;
@@ -792,11 +798,12 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
 {
     uint32_t copy_sz;
     uint32_t img_off;
+    uint32_t max_off;
     int rc;
 
-    /* Calculate offset from start of image area. */
-    img_off = boot_data.imgs[0].sectors[idx].fa_off -
-              boot_data.imgs[0].sectors[0].fa_off;
+    /* Sector offsets are from start of image area. */
+    img_off = boot_data.imgs[0].sectors[idx].fs_off;
+    max_off = boot_data.imgs[0].area->fa_size;
 
     if (bs->state == 0) {
         rc = boot_erase_sector(FLASH_AREA_IMAGE_SCRATCH, 0, sz);
@@ -815,13 +822,14 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
         assert(rc == 0);
 
         copy_sz = sz;
-        if (boot_data.imgs[0].sectors[idx].fa_off + sz >=
-            boot_data.imgs[1].sectors[0].fa_off) {
-
-            /* This is the end of the area.  Don't copy the image state into
+        if (img_off >= max_off - sz) {
+            /*
+             * This is the end of the area.  Don't copy the image state into
              * slot 1.
              */
-            copy_sz -= boot_trailer_sz(boot_data.write_sz);
+            BOOT_LOG_WRN("long write: idx=%d (off=0x%x), size=%u, max_off=%u",
+                         idx, img_off, sz, max_off);
+            copy_sz = max_off - img_off - boot_trailer_sz(boot_data.write_sz);
         }
 
         rc = boot_copy_sector(FLASH_AREA_IMAGE_0, FLASH_AREA_IMAGE_1,
@@ -1012,27 +1020,40 @@ boot_go(struct boot_rsp *rsp)
     int swap_type;
     int slot;
     int rc;
+    int fa_id;
 
     /* The array of slot sectors are defined here (as opposed to file scope) so
      * that they don't get allocated for non-boot-loader apps.  This is
      * necessary because the gcc option "-fdata-sections" doesn't seem to have
      * any effect in older gcc versions (e.g., 4.8.4).
      */
-    static struct flash_area slot0_sectors[BOOT_MAX_IMG_SECTORS];
-    static struct flash_area slot1_sectors[BOOT_MAX_IMG_SECTORS];
+    static struct flash_sector slot0_sectors[BOOT_MAX_IMG_SECTORS];
+    static struct flash_sector slot1_sectors[BOOT_MAX_IMG_SECTORS];
+    static struct flash_sector scratch_sectors[BOOT_MAX_SCRATCH_SECTORS];
+
     boot_data.imgs[0].sectors = slot0_sectors;
     boot_data.imgs[1].sectors = slot1_sectors;
+    boot_data.scratch_sectors = scratch_sectors;
+
+    /* Open boot_data's flash areas for use in this file. */
+    for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
+        fa_id = flash_area_id_from_image_slot(slot);
+        rc = flash_area_open(fa_id, &boot_data.imgs[slot].area);
+        assert(rc == 0);
+    }
+    rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &boot_data.scratch_area);
+    assert(rc == 0);
 
     /* Determine the sector layout of the image slots and scratch area. */
     rc = boot_read_sectors();
     if (rc != 0) {
-        return rc;
+        goto out;
     }
 
     /* Attempt to read an image header from each slot. */
     rc = boot_read_image_headers();
     if (rc != 0) {
-        return rc;
+        goto out;
     }
 
     /* If the image slots aren't compatible, no swap is possible.  Just boot
@@ -1041,7 +1062,7 @@ boot_go(struct boot_rsp *rsp)
     if (boot_slots_compatible()) {
         rc = boot_swap_if_needed(&swap_type);
         if (rc != 0) {
-            return rc;
+            goto out;
         }
     } else {
         swap_type = BOOT_SWAP_TYPE_NONE;
@@ -1052,7 +1073,8 @@ boot_go(struct boot_rsp *rsp)
 #ifdef BOOTUTIL_VALIDATE_SLOT0
         rc = boot_validate_slot(0);
         if (rc != 0) {
-            return BOOT_EBADIMAGE;
+            rc = BOOT_EBADIMAGE;
+            goto out;
         }
 #endif
         slot = 0;
@@ -1085,9 +1107,19 @@ boot_go(struct boot_rsp *rsp)
     }
 
     /* Always boot from the primary slot. */
-    rsp->br_flash_id = boot_data.imgs[0].sectors[0].fa_device_id;
-    rsp->br_image_addr = boot_data.imgs[0].sectors[0].fa_off;
+    rsp->br_flash_id = boot_data.imgs[0].area->fa_device_id;
+    rsp->br_image_addr = boot_data.imgs[0].area->fa_off;
     rsp->br_hdr = &boot_data.imgs[slot].hdr;
+
+ out:
+    /*
+     * We're done using the flash areas now; the boot response
+     * contains the information the caller needs.
+     */
+    for (slot = 0; slot < BOOT_NUM_SLOTS; slot++) {
+        flash_area_close(boot_data.imgs[slot].area);
+    }
+    flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &boot_data.scratch_area);
 
     return 0;
 }
@@ -1095,48 +1127,60 @@ boot_go(struct boot_rsp *rsp)
 int
 split_go(int loader_slot, int split_slot, void **entry)
 {
-    const struct flash_area *loader_fap;
-    const struct flash_area *app_fap;
-    struct flash_area *sectors;
+    struct flash_sector *sectors;
     uintptr_t entry_val;
     int loader_flash_id;
-    int app_flash_id;
+    int split_flash_id;
+    uint32_t loader_num_sectors;
+    uint32_t split_num_sectors;
     int rc;
-
-    app_fap = NULL;
-    loader_fap = NULL;
 
     sectors = malloc(BOOT_MAX_IMG_SECTORS * 2 * sizeof *sectors);
     if (sectors == NULL) {
         rc = SPLIT_GO_ERR;
         goto done;
     }
-    boot_data.imgs[0].sectors = sectors + 0;
-    boot_data.imgs[1].sectors = sectors + BOOT_MAX_IMG_SECTORS;
+    boot_data.imgs[loader_slot].sectors = sectors + 0;
+    boot_data.imgs[split_slot].sectors = sectors + BOOT_MAX_IMG_SECTORS;
 
-    /* Determine the sector layout of the image slots and scratch area. */
-    rc = boot_read_sectors();
+    loader_flash_id = flash_area_id_from_image_slot(loader_slot);
+    rc = flash_area_open(loader_flash_id, &boot_data.imgs[loader_slot].area);
+    if (rc != 0) {
+        rc = BOOT_EFLASH;
+        goto done;
+    }
+
+    split_flash_id = flash_area_id_from_image_slot(split_slot);
+    rc = flash_area_open(split_flash_id, &boot_data.imgs[split_slot].area);
+    if (rc != 0) {
+        rc = BOOT_EFLASH;
+        goto done;
+    }
+
+    /* Determine the sector layout of the image slots.
+     *
+     * A scratch area is not meaningful for split booting, so don't
+     * try to initialize it.
+     */
+    loader_num_sectors = BOOT_MAX_IMG_SECTORS;
+    rc = flash_area_get_sectors(loader_flash_id, &loader_num_sectors,
+                                boot_data.imgs[loader_slot].sectors);
     if (rc != 0) {
         rc = SPLIT_GO_ERR;
         goto done;
     }
+    boot_data.imgs[loader_slot].num_sectors = loader_num_sectors;
+    split_num_sectors = BOOT_MAX_IMG_SECTORS;
+    rc = flash_area_get_sectors(split_flash_id, &split_num_sectors,
+                                boot_data.imgs[split_slot].sectors);
+    if (rc != 0) {
+        rc = SPLIT_GO_ERR;
+        goto done;
+    }
+    boot_data.imgs[split_slot].num_sectors = split_num_sectors;
 
     rc = boot_read_image_headers();
     if (rc != 0) {
-        goto done;
-    }
-
-    app_flash_id = flash_area_id_from_image_slot(split_slot);
-    rc = flash_area_open(app_flash_id, &app_fap);
-    if (rc != 0) {
-        rc = BOOT_EFLASH;
-        goto done;
-    }
-
-    loader_flash_id = flash_area_id_from_image_slot(loader_slot);
-    rc = flash_area_open(loader_flash_id, &loader_fap);
-    if (rc != 0) {
-        rc = BOOT_EFLASH;
         goto done;
     }
 
@@ -1145,22 +1189,22 @@ split_go(int loader_slot, int split_slot, void **entry)
      * passes which is distinct from the normal check.
      */
     rc = split_image_check(&boot_data.imgs[split_slot].hdr,
-                           app_fap,
+                           boot_data.imgs[split_slot].area,
                            &boot_data.imgs[loader_slot].hdr,
-                           loader_fap);
+                           boot_data.imgs[loader_slot].area);
     if (rc != 0) {
         rc = SPLIT_GO_NON_MATCHING;
         goto done;
     }
 
-    entry_val = boot_data.imgs[split_slot].sectors[0].fa_off +
+    entry_val = boot_data.imgs[split_slot].area->fa_off +
                 boot_data.imgs[split_slot].hdr.ih_hdr_size;
     *entry = (void *) entry_val;
     rc = SPLIT_GO_OK;
 
 done:
     free(sectors);
-    flash_area_close(app_fap);
-    flash_area_close(loader_fap);
+    flash_area_close(boot_data.imgs[loader_slot].area);
+    flash_area_close(boot_data.imgs[split_slot].area);
     return rc;
 }

--- a/boot/bootutil/test/src/boot_test_utils.c
+++ b/boot/bootutil/test/src/boot_test_utils.c
@@ -505,7 +505,7 @@ boot_test_util_verify_all(int expected_swap_type,
 
         TEST_ASSERT(memcmp(rsp.br_hdr, slot0hdr, sizeof *slot0hdr) == 0);
         TEST_ASSERT(rsp.br_flash_id == boot_test_img_addrs[0].flash_id);
-        TEST_ASSERT(rsp.br_image_addr == boot_test_img_addrs[0].address);
+        TEST_ASSERT(rsp.br_image_off == boot_test_img_addrs[0].address);
 
         boot_test_util_verify_flash(slot0hdr, orig_slot_0,
                                     slot1hdr, orig_slot_1);

--- a/boot/bootutil/test/src/boot_test_utils.c
+++ b/boot/bootutil/test/src/boot_test_utils.c
@@ -464,6 +464,7 @@ boot_test_util_verify_all(int expected_swap_type,
     const struct image_header *slot0hdr;
     const struct image_header *slot1hdr;
     struct boot_rsp rsp;
+    uintptr_t flash_base;
     int orig_slot_0;
     int orig_slot_1;
     int num_swaps;
@@ -503,9 +504,13 @@ boot_test_util_verify_all(int expected_swap_type,
             orig_slot_1 = 0;
         }
 
+        rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+        TEST_ASSERT_FATAL(rc == 0);
+
         TEST_ASSERT(memcmp(rsp.br_hdr, slot0hdr, sizeof *slot0hdr) == 0);
         TEST_ASSERT(rsp.br_flash_dev_id == boot_test_img_addrs[0].flash_id);
-        TEST_ASSERT(rsp.br_image_off == boot_test_img_addrs[0].address);
+        TEST_ASSERT(flash_base + rsp.br_image_off ==
+                    boot_test_img_addrs[0].address);
 
         boot_test_util_verify_flash(slot0hdr, orig_slot_0,
                                     slot1hdr, orig_slot_1);

--- a/boot/bootutil/test/src/boot_test_utils.c
+++ b/boot/bootutil/test/src/boot_test_utils.c
@@ -504,7 +504,7 @@ boot_test_util_verify_all(int expected_swap_type,
         }
 
         TEST_ASSERT(memcmp(rsp.br_hdr, slot0hdr, sizeof *slot0hdr) == 0);
-        TEST_ASSERT(rsp.br_flash_id == boot_test_img_addrs[0].flash_id);
+        TEST_ASSERT(rsp.br_flash_dev_id == boot_test_img_addrs[0].flash_id);
         TEST_ASSERT(rsp.br_image_off == boot_test_img_addrs[0].address);
 
         boot_test_util_verify_flash(slot0hdr, orig_slot_0,

--- a/boot/zephyr/flash_map.c
+++ b/boot/zephyr/flash_map.c
@@ -32,26 +32,49 @@
 extern struct device *boot_flash_device;
 
 /*
+ * For now, we only support one flash device.
+ *
+ * Pick a random device ID for it that's unlikely to collide with
+ * anything "real".
+ */
+#define FLASH_DEVICE_ID 100
+#define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
+
+/*
  * The flash area describes essentially the partition table of the
  * flash.  In this case, it starts with FLASH_AREA_IMAGE_0.
  */
 static const struct flash_area part_map[] = {
     {
         .fa_id = FLASH_AREA_IMAGE_0,
+        .fa_device_id = FLASH_DEVICE_ID,
         .fa_off = FLASH_AREA_IMAGE_0_OFFSET,
         .fa_size = FLASH_AREA_IMAGE_0_SIZE,
     },
     {
         .fa_id = FLASH_AREA_IMAGE_1,
+        .fa_device_id = FLASH_DEVICE_ID,
         .fa_off = FLASH_AREA_IMAGE_1_OFFSET,
         .fa_size = FLASH_AREA_IMAGE_1_SIZE,
     },
     {
         .fa_id = FLASH_AREA_IMAGE_SCRATCH,
+        .fa_device_id = FLASH_DEVICE_ID,
         .fa_off = FLASH_AREA_IMAGE_SCRATCH_OFFSET,
         .fa_size = FLASH_AREA_IMAGE_SCRATCH_SIZE,
     },
 };
+
+int flash_device_base(uint8_t fd_id, uintptr_t *ret)
+{
+    if (fd_id != FLASH_DEVICE_ID) {
+        BOOT_LOG_ERR("invalid flash ID %d; expected %d",
+                     fd_id, FLASH_DEVICE_ID);
+        return -EINVAL;
+    }
+    *ret = FLASH_DEVICE_BASE;
+    return 0;
+}
 
 /*
  * `open` a flash area.  The `area` in this case is not the individual

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -43,11 +43,35 @@ extern "C" {
  */
 #include <inttypes.h>
 
+/**
+ * @brief Structure describing an area on a flash device.
+ *
+ * Multiple flash devices may be available in the system, each of
+ * which may have its own areas. For this reason, flash areas track
+ * which flash device they are part of.
+ */
 struct flash_area {
+    /**
+     * This flash area's ID; unique in the system.
+     */
     uint8_t fa_id;
+
+    /**
+     * ID of the flash device this area is a part of.
+     */
     uint8_t fa_device_id;
+
     uint16_t pad16;
+
+    /**
+     * This area's offset, relative to the beginning of its flash
+     * device's storage.
+     */
     uint32_t fa_off;
+
+    /**
+     * This area's size, in bytes.
+     */
     uint32_t fa_size;
 };
 

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -76,6 +76,16 @@ struct flash_area {
 };
 
 /*
+ * Retrieve a memory-mapped flash device's base address.
+ *
+ * On success, the address will be stored in the value pointed to by
+ * ret.
+ *
+ * Returns 0 on success, or an error code on failure.
+ */
+int flash_device_base(uint8_t fd_id, uintptr_t *ret);
+
+/*
  * Start using flash area.
  */
 int flash_area_open(uint8_t id, const struct flash_area **);

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -75,6 +75,25 @@ struct flash_area {
     uint32_t fa_size;
 };
 
+/**
+ * @brief Structure describing a sector within a flash area.
+ *
+ * Each sector has an offset relative to the start of its flash area
+ * (NOT relative to the start of its flash device), and a size. A
+ * flash area may contain sectors with different sizes.
+ */
+struct flash_sector {
+    /**
+     * Offset of this sector, from the start of its flash area (not device).
+     */
+    uint32_t fs_off;
+
+    /**
+     * Size of this sector, in bytes.
+     */
+    uint32_t fs_size;
+};
+
 /*
  * Retrieve a memory-mapped flash device's base address.
  *
@@ -107,8 +126,16 @@ int flash_area_erase(const struct flash_area *, uint32_t off, uint32_t len);
 uint8_t flash_area_align(const struct flash_area *);
 
 /*
- * Given flash map index, return info about sectors within the area.
+ * Given flash area ID, return info about sectors within the area.
  */
+int flash_area_get_sectors(int fa_id, uint32_t *count,
+  struct flash_sector *sectors);
+
+/*
+ * Similar to flash_area_get_sectors(), but return the values in an
+ * array of struct flash_area instead.
+ */
+__attribute__((deprecated))
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);
 
 int flash_area_id_from_image_slot(int slot);

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <assert.h>
 #include <zephyr.h>
 #include <flash.h>
 #include <asm_inline.h>
@@ -25,6 +26,7 @@
 #include "bootutil/bootutil_log.h"
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"
+#include "flash_map/flash_map.h"
 
 struct device *boot_flash_device;
 
@@ -39,13 +41,19 @@ struct arm_vector_table {
 static void do_boot(struct boot_rsp *rsp)
 {
     struct arm_vector_table *vt;
+    uintptr_t flash_base;
+    int rc;
 
     /* The beginning of the image is the ARM vector table, containing
      * the initial stack pointer address and the reset vector
      * consecutively. Manually set the stack pointer and jump into the
      * reset vector
      */
-    vt = (struct arm_vector_table *)(rsp->br_image_off +
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    assert(rc == 0);
+
+    vt = (struct arm_vector_table *)(flash_base +
+                                     rsp->br_image_off +
                                      rsp->br_hdr->ih_hdr_size);
     irq_lock();
     sys_clock_disable();
@@ -59,9 +67,15 @@ static void do_boot(struct boot_rsp *rsp)
  */
 static void do_boot(struct boot_rsp *rsp)
 {
+    uintptr_t flash_base;
     void *start;
+    int rc;
 
-    start = (void *)(rsp->br_image_off + rsp->br_hdr->ih_hdr_size);
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    assert(rc == 0);
+
+    start = (void *)(flash_base + rsp->br_image_off +
+                     rsp->br_hdr->ih_hdr_size);
 
     /* Lock interrupts and dive into the entry point */
     irq_lock();

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -38,6 +38,8 @@ struct arm_vector_table {
     uint32_t reset;
 };
 
+extern void zephyr_flash_area_warn_on_open(void);
+
 static void do_boot(struct boot_rsp *rsp)
 {
     struct arm_vector_table *vt;
@@ -108,6 +110,7 @@ void main(void)
 
     BOOT_LOG_INF("Bootloader chainload address offset: 0x%x",
                  rsp.br_image_off);
+    zephyr_flash_area_warn_on_open();
     BOOT_LOG_INF("Jumping to the first image slot");
     do_boot(&rsp);
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -45,7 +45,7 @@ static void do_boot(struct boot_rsp *rsp)
      * consecutively. Manually set the stack pointer and jump into the
      * reset vector
      */
-    vt = (struct arm_vector_table *)(rsp->br_image_addr +
+    vt = (struct arm_vector_table *)(rsp->br_image_off +
                                      rsp->br_hdr->ih_hdr_size);
     irq_lock();
     sys_clock_disable();
@@ -61,7 +61,7 @@ static void do_boot(struct boot_rsp *rsp)
 {
     void *start;
 
-    start = (void *)(rsp->br_image_addr + rsp->br_hdr->ih_hdr_size);
+    start = (void *)(rsp->br_image_off + rsp->br_hdr->ih_hdr_size);
 
     /* Lock interrupts and dive into the entry point */
     irq_lock();
@@ -92,7 +92,8 @@ void main(void)
             ;
     }
 
-    BOOT_LOG_INF("Bootloader chainload address: 0x%x", rsp.br_image_addr);
+    BOOT_LOG_INF("Bootloader chainload address offset: 0x%x",
+                 rsp.br_image_off);
     BOOT_LOG_INF("Jumping to the first image slot");
     do_boot(&rsp);
 


### PR DESCRIPTION
This series fixes MCUB-54 on Zephyr targets.

@d3zd3z, I could use some advice on how to port flash_area_get_sectors() to the simulator if you have some time. It's broken as-is, and I don't know Rust.

@mkiiskila, I hope this addresses your feedback and that it's acceptable for porting to MyNewt core.

The series adds new flash_device_base() and flash_area_get_sectors() routines to flash_map.h. If accepted, it needs to be propagated to mynewt as well, as it also ports the core bootutil library to use flash_area_get_sectors().

While updating split_go() to use flash_area_get_sectors(), I discovered it makes use of helper routines meant for boot_go(), which aren't quite right. Things are improved in "bootutil: use flash_area_get_sectors()", but more work is needed (see https://runtimeco.atlassian.net/browse/MCUB-56).

This series is based on https://github.com/runtimeco/mcuboot/pull/45, and incorporates feedback given there.

With these core updates, the Zephyr bootloader now uses flash_device_base() to fix a bug that manifests on STM32 devices depending on the MCU configuration, and warns when flash areas are left open at the end of boot.
