### PR TITLE
Add support for "signing" without a signature

### DIFF
--- a/scripts/imgtool.py
+++ b/scripts/imgtool.py
@@ -35,7 +35,7 @@ def do_sign(args):
     img = image.Image.load(args.infile, version=args.version,
             header_size=args.header_size,
             pad=args.pad)
-    key = keys.load(args.key)
+    key = keys.load(args.key) if args.key else None
     img.sign(key)
 
     if args.pad:
@@ -75,7 +75,7 @@ def args():
     getpub.add_argument('-k', '--key', metavar='filename', required=True)
 
     sign = subs.add_parser('sign', help='Sign an image with a private key')
-    sign.add_argument('-k', '--key', metavar='filename', required=True)
+    sign.add_argument('-k', '--key', metavar='filename')
     sign.add_argument("--align", type=alignment_value, required=True)
     sign.add_argument("-v", "--version", type=version.decode_version, required=True)
     sign.add_argument("-H", "--header-size", type=intparse, required=True)

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -101,8 +101,9 @@ class Image():
 
         tlv.add('SHA256', digest)
 
-        sig = key.sign(self.payload)
-        tlv.add(key.sig_tlv(), sig)
+        if key is not None:
+            sig = key.sign(self.payload)
+            tlv.add(key.sig_tlv(), sig)
 
         self.payload += tlv.get()
 
@@ -112,9 +113,11 @@ class Image():
         The key is needed to know the type of signature, and
         approximate the size of the signature."""
 
-        flags = IMAGE_F[key.sig_type()]
+        flags = 0
         tlvsz = 0
-        tlvsz += TLV_HEADER_SIZE + key.sig_len()
+        if key is not None:
+            flags |= IMAGE_F[key.sig_type()]
+            tlvsz += TLV_HEADER_SIZE + key.sig_len()
 
         flags |= IMAGE_F['SHA256']
         tlvsz += 4 + hashlib.sha256().digest_size


### PR DESCRIPTION
This helps with development, allowing the image to only get headers and a SHA256 hash.

Note that this PR includes PR#53, and should not be merged until it is merged.  Only the last commit is relevant to this patch.