### PR TITLE
Make header padding optional

### DIFF
--- a/doc/imgtool.md
+++ b/doc/imgtool.md
@@ -66,6 +66,7 @@ header and trailer that the bootloader is expecting:
       --align ALIGN
       -v VERSION, --version VERSION
       -H HEADER_SIZE, --header-size HEADER_SIZE
+      --included-header     Image has gap for header
       --pad PAD             Pad image to this many bytes, adding trailer magic
       --rsa-pkcs1-15        Use old PKCS#1 v1.5 signature algorithm
 
@@ -75,8 +76,10 @@ flash device in question, and the header size.
 
 The header size depends on the operating system and the particular
 flash device.  For Zephyr, it will be configured as part of the build,
-and will be a small power of two.  The generated image should start
-with zero bytes of this length (and the script will check this).
+and will be a small power of two.  By default, the header will be
+prepended to the image.  If `--included-header` is given, the image
+must start with header-size bytes of zeros, and the header will be
+overwritten over these bytes.
 
 The optional --pad argument will place a trailer on the image that
 indicates that the image should be considered an upgrade.  Writing

--- a/scripts/imgtool.py
+++ b/scripts/imgtool.py
@@ -34,6 +34,7 @@ def do_sign(args):
         keys.sign_rsa_pss = False
     img = image.Image.load(args.infile, version=args.version,
             header_size=args.header_size,
+            included_header=args.included_header,
             pad=args.pad)
     key = keys.load(args.key)
     img.sign(key)
@@ -79,6 +80,8 @@ def args():
     sign.add_argument("--align", type=alignment_value, required=True)
     sign.add_argument("-v", "--version", type=version.decode_version, required=True)
     sign.add_argument("-H", "--header-size", type=intparse, required=True)
+    sign.add_argument("--included-header", default=False, action='store_true',
+            help='Image has gap for header')
     sign.add_argument("--pad", type=intparse,
             help='Pad image to this many bytes, adding trailer magic')
     sign.add_argument("--rsa-pkcs1-15", help='Use old PKCS#1 v1.5 signature algorithm',

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -55,12 +55,17 @@ class TLV():
 
 class Image():
     @classmethod
-    def load(cls, path, **kwargs):
+    def load(cls, path, included_header=False, **kwargs):
         """Load an image from a given file"""
         with open(path, 'rb') as f:
             payload = f.read()
         obj = cls(**kwargs)
         obj.payload = payload
+
+        # Add the image header if needed.
+        if not included_header and obj.header_size > 0:
+            obj.payload = (b'\000' * obj.header_size) + obj.payload
+
         obj.check()
         return obj
 


### PR DESCRIPTION
Zephyr defaults to having zero bytes at the beginning of the binary image as a gap allowing for the header. Other targets do not, so accommodate that.

This is built on top of pr#53 and shouldn't be merged until it goes in. Only the last patch is relevant to this PR.