### PR TITLE
Fix broken Mynewt BOOTUTIL_ -> MCUBOOT_ mapping

### DIFF
--- a/boot/bootutil/src/image_ec.c
+++ b/boot/bootutil/src/image_ec.c
@@ -19,6 +19,10 @@
 
 #include <string.h>
 
+#ifdef APP_mynewt
+#include "mynewt/config.h"
+#endif
+
 #ifdef MCUBOOT_SIGN_EC
 #include "bootutil/sign_key.h"
 

--- a/boot/bootutil/src/image_ec256.c
+++ b/boot/bootutil/src/image_ec256.c
@@ -19,6 +19,10 @@
 
 #include <string.h>
 
+#ifdef APP_mynewt
+#include "mynewt/config.h"
+#endif
+
 #ifdef MCUBOOT_SIGN_EC256
 #include "bootutil/sign_key.h"
 

--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -19,6 +19,10 @@
 
 #include <string.h>
 
+#ifdef APP_mynewt
+#include "mynewt/config.h"
+#endif
+
 #ifdef MCUBOOT_SIGN_RSA
 #include "bootutil/sign_key.h"
 

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -28,6 +28,10 @@
 #include "bootutil/sha256.h"
 #include "bootutil/sign_key.h"
 
+#ifdef APP_mynewt
+#include "mynewt/config.h"
+#endif
+
 #ifdef MCUBOOT_SIGN_RSA
 #include "mbedtls/rsa.h"
 #endif

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -38,6 +38,10 @@
 #define BOOT_LOG_LEVEL BOOT_LOG_LEVEL_INFO
 #include "bootutil/bootutil_log.h"
 
+#ifdef APP_mynewt
+#include "mynewt/config.h"
+#endif
+
 #define BOOT_MAX_IMG_SECTORS        120
 
 /** Number of image slots in flash; currently limited to two. */


### PR DESCRIPTION
Fix mapping of syscfg.yml BOOTUTIL_* vars to C #defines, which was broken
on most .c files for lacking inclusion of mynewt "config.h"