### PR TITLE
Flash map updates, redux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ CFLAGS += -DMCUBOOT_SIGN_RSA -DMCUBOOT_USE_MBED_TLS
 # verification only happens on upgrade.
 CFLAGS += -DMCUBOOT_VALIDATE_SLOT0
 
+# Enabling this option uses newer flash map APIs. This saves RAM and
+# avoids deprecated API usage.
+#
+# (This can be deleted when flash_area_to_sectors() is removed instead
+# of simply deprecated.)
+CFLAGS += -DMCUBOOT_USE_FLASH_AREA_GET_SECTORS
+
 # Enable this option to not use the swapping code and just overwrite
 # the image on upgrade.
 #CFLAGS += -DMCUBOOT_OVERWRITE_ONLY

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -51,10 +51,10 @@ struct boot_rsp {
 
     /**
      * The flash offset of the image to execute.  Indicates the position of
-     * the image header.
+     * the image header within its flash device.
      */
     uint8_t br_flash_id;
-    uint32_t br_image_addr;
+    uint32_t br_image_off;
 };
 
 /* you must have pre-allocated all the entries within this structure */

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -53,7 +53,7 @@ struct boot_rsp {
      * The flash offset of the image to execute.  Indicates the position of
      * the image header within its flash device.
      */
-    uint8_t br_flash_id;
+    uint8_t br_flash_dev_id;
     uint32_t br_image_off;
 };
 

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -20,6 +20,7 @@
 #ifndef H_BOOTUTIL_PRIV_
 #define H_BOOTUTIL_PRIV_
 
+#include "flash_map/flash_map.h"
 #include "bootutil/image.h"
 
 #ifdef __cplusplus
@@ -93,6 +94,22 @@ struct boot_swap_state {
 #define BOOT_FLAG_UNSET            0xff
 
 extern const uint32_t BOOT_MAGIC_SZ;
+
+/** Number of image slots in flash; currently limited to two. */
+#define BOOT_NUM_SLOTS              2
+
+/** Private state maintained during boot. */
+struct boot_loader_state {
+    struct {
+        struct image_header hdr;
+        struct flash_area *sectors;
+        int num_sectors;
+    } imgs[BOOT_NUM_SLOTS];
+
+    struct flash_area scratch_sector;
+
+    uint8_t write_sz;
+};
 
 int bootutil_verify_sig(uint8_t *hash, uint32_t hlen, uint8_t *sig, int slen,
     uint8_t key_id);

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -149,6 +149,31 @@ boot_scratch_fa_device_id(struct boot_loader_state *state)
     return state->scratch_sector.fa_device_id;
 }
 
+static inline size_t
+boot_img_num_sectors(struct boot_loader_state *state, size_t slot)
+{
+    return state->imgs[slot].num_sectors;
+}
+
+static inline void
+boot_img_set_num_sectors(struct boot_loader_state *state, size_t slot,
+                         size_t num_sectors)
+{
+    state->imgs[slot].num_sectors = num_sectors;
+}
+
+static inline size_t
+boot_img_sector_size(struct boot_loader_state *state,
+                     size_t slot, size_t sector)
+{
+    return state->imgs[slot].sectors[sector].fa_size;
+}
+
+static inline size_t boot_scratch_area_size(struct boot_loader_state *state)
+{
+    return state->scratch_sector.fa_size;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -164,6 +164,20 @@ boot_img_num_sectors(struct boot_loader_state *state, size_t slot)
     return state->imgs[slot].num_sectors;
 }
 
+/*
+ * Offset of the slot from the beginning of the flash device.
+ */
+static inline uint32_t
+boot_img_slot_off(struct boot_loader_state *state, size_t slot)
+{
+    return state->imgs[slot].area->fa_off;
+}
+
+static inline size_t boot_scratch_area_size(struct boot_loader_state *state)
+{
+    return state->scratch_area->fa_size;
+}
+
 static inline size_t
 boot_img_sector_size(struct boot_loader_state *state,
                      size_t slot, size_t sector)
@@ -181,20 +195,6 @@ boot_img_sector_off(struct boot_loader_state *state, size_t slot,
 {
     return state->imgs[slot].sectors[sector].fa_off -
            state->imgs[slot].sectors[0].fa_off;
-}
-
-/*
- * Offset of the slot from the beginning of the flash device.
- */
-static inline uint32_t
-boot_img_slot_off(struct boot_loader_state *state, size_t slot)
-{
-    return state->imgs[slot].area->fa_off;
-}
-
-static inline size_t boot_scratch_area_size(struct boot_loader_state *state)
-{
-    return state->scratch_area->fa_size;
 }
 
 static inline int

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -139,6 +139,7 @@ int boot_write_image_ok(const struct flash_area *fap);
 /* These are macros so they can be used as lvalues. */
 #define BOOT_IMG_AREA(state, slot) ((state)->imgs[(slot)].area)
 #define BOOT_SCRATCH_AREA(state) ((state)->scratch_area)
+#define BOOT_WRITE_SZ(state) ((state)->write_sz)
 
 static inline struct image_header*
 boot_img_hdr(struct boot_loader_state *state, size_t slot)

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -137,6 +137,18 @@ boot_img_hdr(struct boot_loader_state *state, size_t slot)
     return &state->imgs[slot].hdr;
 }
 
+static inline uint8_t
+boot_img_fa_device_id(struct boot_loader_state *state, size_t slot)
+{
+    return state->imgs[slot].sectors[0].fa_device_id;
+}
+
+static inline uint8_t
+boot_scratch_fa_device_id(struct boot_loader_state *state)
+{
+    return state->scratch_sector.fa_device_id;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -127,9 +127,18 @@ int boot_schedule_test_swap(void);
 int boot_write_copy_done(const struct flash_area *fap);
 int boot_write_image_ok(const struct flash_area *fap);
 
+/*
+ * Accessors for the contents of struct boot_loader_state.
+ */
+
+static inline struct image_header*
+boot_img_hdr(struct boot_loader_state *state, size_t slot)
+{
+    return &state->imgs[slot].hdr;
+}
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -108,7 +108,7 @@ struct boot_loader_state {
         struct image_header hdr;
         const struct flash_area *area;
         struct flash_area *sectors;
-        int num_sectors;
+        size_t num_sectors;
     } imgs[BOOT_NUM_SLOTS];
 
     const struct flash_area *scratch_area;
@@ -220,7 +220,7 @@ boot_initialize_area(struct boot_loader_state *state, int flash_area)
     if (rc != 0) {
         return rc;
     }
-    state->imgs[slot].num_sectors = num_sectors;
+    state->imgs[slot].num_sectors = (size_t)num_sectors;
     return 0;
 }
 

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -166,6 +166,32 @@ boot_img_sector_size(struct boot_loader_state *state,
     return state->imgs[slot].sectors[sector].fa_size;
 }
 
+/*
+ * Offset of the sector from the beginning of the image, NOT the flash
+ * device.
+ */
+static inline uint32_t
+boot_img_sector_off(struct boot_loader_state *state, size_t slot,
+                    size_t sector)
+{
+    return state->imgs[slot].sectors[sector].fa_off -
+           state->imgs[slot].sectors[0].fa_off;
+}
+
+/*
+ * Offset of the slot from the beginning of the flash device.
+ */
+static inline uint32_t
+boot_img_slot_off(struct boot_loader_state *state, size_t slot)
+{
+    /*
+     * When using flash_area_to_sectors(), "sectors" are actually
+     * flash areas. Flash areas have offsets relative to the beginning
+     * of their flash device.
+     */
+    return state->imgs[slot].sectors[0].fa_off;
+}
+
 static inline size_t boot_scratch_area_size(struct boot_loader_state *state)
 {
     return state->scratch_sector.fa_size;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1288,7 +1288,7 @@ boot_go(struct boot_rsp *rsp)
 
     /* Always boot from the primary slot. */
     rsp->br_flash_id = boot_img_fa_device_id(&boot_data, 0);
-    rsp->br_image_addr = boot_img_slot_off(&boot_data, 0);
+    rsp->br_image_off = boot_img_slot_off(&boot_data, 0);
     rsp->br_hdr = boot_img_hdr(&boot_data, slot);
 
  out:

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -285,8 +285,8 @@ boot_write_sz(void)
      * on what the minimum write size is for scratch area, active image slot.
      * We need to use the bigger of those 2 values.
      */
-    elem_sz = hal_flash_align(boot_data.imgs[0].sectors[0].fa_device_id);
-    align = hal_flash_align(boot_data.scratch_sector.fa_device_id);
+    elem_sz = hal_flash_align(boot_img_fa_device_id(&boot_data, 0));
+    align = hal_flash_align(boot_scratch_fa_device_id(&boot_data));
     if (align > elem_sz) {
         elem_sz = align;
     }
@@ -1290,7 +1290,7 @@ boot_go(struct boot_rsp *rsp)
     }
 
     /* Always boot from the primary slot. */
-    rsp->br_flash_id = boot_data.imgs[0].sectors[0].fa_device_id;
+    rsp->br_flash_id = boot_img_fa_device_id(&boot_data, 0);
     rsp->br_image_addr = boot_data.imgs[0].sectors[0].fa_off;
     rsp->br_hdr = boot_img_hdr(&boot_data, slot);
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1287,7 +1287,7 @@ boot_go(struct boot_rsp *rsp)
     }
 
     /* Always boot from the primary slot. */
-    rsp->br_flash_id = boot_img_fa_device_id(&boot_data, 0);
+    rsp->br_flash_dev_id = boot_img_fa_device_id(&boot_data, 0);
     rsp->br_image_off = boot_img_slot_off(&boot_data, 0);
     rsp->br_hdr = boot_img_hdr(&boot_data, slot);
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1196,7 +1196,7 @@ int
 boot_go(struct boot_rsp *rsp)
 {
     int swap_type;
-    int slot;
+    size_t slot;
     int rc;
     int fa_id;
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -28,7 +28,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include "sysflash/sysflash.h"
-#include "flash_map/flash_map.h"
 #include <hal/hal_flash.h>
 #include <os/os_malloc.h>
 #include "bootutil/bootutil.h"
@@ -44,20 +43,7 @@
 
 #define BOOT_MAX_IMG_SECTORS        120
 
-/** Number of image slots in flash; currently limited to two. */
-#define BOOT_NUM_SLOTS              2
-
-static struct {
-    struct {
-        struct image_header hdr;
-        struct flash_area *sectors;
-        int num_sectors;
-    } imgs[BOOT_NUM_SLOTS];
-
-    struct flash_area scratch_sector;
-
-    uint8_t write_sz;
-} boot_data;
+static struct boot_loader_state boot_data;
 
 struct boot_status_table {
     /**

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -27,7 +27,6 @@
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
-#include "sysflash/sysflash.h"
 #include <hal/hal_flash.h>
 #include <os/os_malloc.h>
 #include "bootutil/bootutil.h"
@@ -40,8 +39,6 @@
 #ifdef APP_mynewt
 #include "mynewt/config.h"
 #endif
-
-#define BOOT_MAX_IMG_SECTORS        120
 
 static struct boot_loader_state boot_data;
 
@@ -326,32 +323,22 @@ boot_slots_compatible(void)
 static int
 boot_read_sectors(void)
 {
-    const struct flash_area *scratch;
-    int num_sectors_slot0;
-    int num_sectors_slot1;
     int rc;
 
-    num_sectors_slot0 = BOOT_MAX_IMG_SECTORS;
-    rc = flash_area_to_sectors(FLASH_AREA_IMAGE_0, &num_sectors_slot0,
-                               boot_data.imgs[0].sectors);
+    rc = boot_initialize_area(&boot_data, FLASH_AREA_IMAGE_0);
     if (rc != 0) {
         return BOOT_EFLASH;
     }
-    boot_img_set_num_sectors(&boot_data, 0, num_sectors_slot0);
 
-    num_sectors_slot1 = BOOT_MAX_IMG_SECTORS;
-    rc = flash_area_to_sectors(FLASH_AREA_IMAGE_1, &num_sectors_slot1,
-                               boot_data.imgs[1].sectors);
+    rc = boot_initialize_area(&boot_data, FLASH_AREA_IMAGE_1);
     if (rc != 0) {
         return BOOT_EFLASH;
     }
-    boot_img_set_num_sectors(&boot_data, 1, num_sectors_slot1);
 
-    rc = flash_area_open(FLASH_AREA_IMAGE_SCRATCH, &scratch);
+    rc = boot_initialize_area(&boot_data, FLASH_AREA_IMAGE_SCRATCH);
     if (rc != 0) {
         return BOOT_EFLASH;
     }
-    boot_data.scratch_sector = *scratch;
 
     boot_data.write_sz = boot_write_sz();
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1207,8 +1207,8 @@ boot_go(struct boot_rsp *rsp)
      * necessary because the gcc option "-fdata-sections" doesn't seem to have
      * any effect in older gcc versions (e.g., 4.8.4).
      */
-    static struct flash_area slot0_sectors[BOOT_MAX_IMG_SECTORS];
-    static struct flash_area slot1_sectors[BOOT_MAX_IMG_SECTORS];
+    static boot_sector_t slot0_sectors[BOOT_MAX_IMG_SECTORS];
+    static boot_sector_t slot1_sectors[BOOT_MAX_IMG_SECTORS];
     boot_data.imgs[0].sectors = slot0_sectors;
     boot_data.imgs[1].sectors = slot1_sectors;
 
@@ -1302,7 +1302,7 @@ boot_go(struct boot_rsp *rsp)
 int
 split_go(int loader_slot, int split_slot, void **entry)
 {
-    struct flash_area *sectors;
+    boot_sector_t *sectors;
     uintptr_t entry_val;
     int loader_flash_id;
     int split_flash_id;

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -335,7 +335,7 @@ boot_read_sectors(void)
         return BOOT_EFLASH;
     }
 
-    boot_data.write_sz = boot_write_sz();
+    BOOT_WRITE_SZ(&boot_data) = boot_write_sz();
 
     return 0;
 }
@@ -370,7 +370,8 @@ boot_read_status_bytes(const struct flash_area *fap, struct boot_status *bs)
 
     found = 0;
     for (i = 0; i < max_entries; i++) {
-        rc = flash_area_read(fap, off + i * boot_data.write_sz, &status, 1);
+        rc = flash_area_read(fap, off + i * BOOT_WRITE_SZ(&boot_data),
+                             &status, 1);
         if (rc != 0) {
             return BOOT_EFLASH;
         }
@@ -473,7 +474,8 @@ boot_write_status(struct boot_status *bs)
     }
 
     off = boot_status_off(fap) +
-          boot_status_internal_off(bs->idx, bs->state, boot_data.write_sz);
+          boot_status_internal_off(bs->idx, bs->state,
+                                   BOOT_WRITE_SZ(&boot_data));
 
     align = hal_flash_align(fap->fa_device_id);
     memset(buf, 0xFF, 8);
@@ -829,7 +831,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
     img_off = boot_img_sector_off(&boot_data, 0, idx);
 
     copy_sz = sz;
-    trailer_sz = boot_slots_trailer_sz(boot_data.write_sz);
+    trailer_sz = boot_slots_trailer_sz(BOOT_WRITE_SZ(&boot_data));
 
     /* sz in this function is always is always sized on a multiple of the
      * sector size. The check against the start offset of the last sector
@@ -918,9 +920,9 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
 
             /* copy current status that is being maintained in scratch */
             rc = boot_copy_sector(FLASH_AREA_IMAGE_SCRATCH, FLASH_AREA_IMAGE_0,
-                            scratch_trailer_off,
-                            img_off + copy_sz + BOOT_MAGIC_SZ,
-                            BOOT_STATUS_STATE_COUNT * boot_data.write_sz);
+                        scratch_trailer_off,
+                        img_off + copy_sz + BOOT_MAGIC_SZ,
+                        BOOT_STATUS_STATE_COUNT * BOOT_WRITE_SZ(&boot_data));
             assert(rc == 0);
 
             rc = boot_read_swap_state_by_id(FLASH_AREA_IMAGE_SCRATCH,

--- a/boot/bootutil/test/src/boot_test_utils.c
+++ b/boot/bootutil/test/src/boot_test_utils.c
@@ -505,7 +505,7 @@ boot_test_util_verify_all(int expected_swap_type,
 
         TEST_ASSERT(memcmp(rsp.br_hdr, slot0hdr, sizeof *slot0hdr) == 0);
         TEST_ASSERT(rsp.br_flash_id == boot_test_img_addrs[0].flash_id);
-        TEST_ASSERT(rsp.br_image_addr == boot_test_img_addrs[0].address);
+        TEST_ASSERT(rsp.br_image_off == boot_test_img_addrs[0].address);
 
         boot_test_util_verify_flash(slot0hdr, orig_slot_0,
                                     slot1hdr, orig_slot_1);

--- a/boot/bootutil/test/src/boot_test_utils.c
+++ b/boot/bootutil/test/src/boot_test_utils.c
@@ -464,6 +464,7 @@ boot_test_util_verify_all(int expected_swap_type,
     const struct image_header *slot0hdr;
     const struct image_header *slot1hdr;
     struct boot_rsp rsp;
+    uintptr_t flash_base;
     int orig_slot_0;
     int orig_slot_1;
     int num_swaps;
@@ -503,9 +504,13 @@ boot_test_util_verify_all(int expected_swap_type,
             orig_slot_1 = 0;
         }
 
+        rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+        TEST_ASSERT_FATAL(rc == 0);
+
         TEST_ASSERT(memcmp(rsp.br_hdr, slot0hdr, sizeof *slot0hdr) == 0);
         TEST_ASSERT(rsp.br_flash_dev_id == boot_test_img_addrs[0].flash_id);
-        TEST_ASSERT(rsp.br_image_off == boot_test_img_addrs[0].address);
+        TEST_ASSERT(flash_base + rsp.br_image_off ==
+                    boot_test_img_addrs[0].address);
 
         boot_test_util_verify_flash(slot0hdr, orig_slot_0,
                                     slot1hdr, orig_slot_1);

--- a/boot/bootutil/test/src/boot_test_utils.c
+++ b/boot/bootutil/test/src/boot_test_utils.c
@@ -504,7 +504,7 @@ boot_test_util_verify_all(int expected_swap_type,
         }
 
         TEST_ASSERT(memcmp(rsp.br_hdr, slot0hdr, sizeof *slot0hdr) == 0);
-        TEST_ASSERT(rsp.br_flash_id == boot_test_img_addrs[0].flash_id);
+        TEST_ASSERT(rsp.br_flash_dev_id == boot_test_img_addrs[0].flash_id);
         TEST_ASSERT(rsp.br_image_off == boot_test_img_addrs[0].address);
 
         boot_test_util_verify_flash(slot0hdr, orig_slot_0,

--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -43,10 +43,23 @@
 #define BOOT_SER_CONS_INPUT         128
 #endif
 
+/*
+ * Temporary flash_device_base() implementation.
+ *
+ * TODO: remove this when mynewt needs to support flash_device_base()
+ * for devices with nonzero base addresses.
+ */
+int flash_device_base(uint8_t fd_id, uintptr_t *ret)
+{
+    *ret = 0;
+    return 0;
+}
+
 int
 main(void)
 {
     struct boot_rsp rsp;
+    uintptr_t flash_base;
     int rc;
 
 #ifdef MCUBOOT_SERIAL
@@ -70,7 +83,11 @@ main(void)
     rc = boot_go(&rsp);
     assert(rc == 0);
 
-    hal_system_start((void *)(rsp.br_image_off + rsp.br_hdr->ih_hdr_size));
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    assert(rc == 0);
+
+    hal_system_start((void *)(flash_base + rsp.br_image_off +
+                              rsp.br_hdr->ih_hdr_size));
 
     return 0;
 }

--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -70,7 +70,7 @@ main(void)
     rc = boot_go(&rsp);
     assert(rc == 0);
 
-    hal_system_start((void *)(rsp.br_image_addr + rsp.br_hdr->ih_hdr_size));
+    hal_system_start((void *)(rsp.br_image_off + rsp.br_hdr->ih_hdr_size));
 
     return 0;
 }

--- a/boot/zephyr/flash_map.c
+++ b/boot/zephyr/flash_map.c
@@ -155,19 +155,8 @@ int flash_area_id_from_image_slot(int slot)
 #define FLASH_AREA_IMAGE_SECTOR_SIZE FLASH_AREA_IMAGE_SCRATCH_SIZE
 #endif
 
-/*
- * Lookup the sector map for a given flash area.  This should fill in
- * `ret` with all of the sectors in the area.  `*cnt` will be set to
- * the storage at `ret` and should be set to the final number of
- * sectors in this area.
- */
-int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
+static int validate_idx(int idx, uint32_t *off, uint32_t *len)
 {
-    uint32_t off;
-    uint32_t len;
-    uint32_t max_cnt = *cnt;
-    uint32_t rem_len;
-
     /*
      * This simple layout has uniform slots, so just fill in the
      * right one.
@@ -176,22 +165,18 @@ int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
         return -1;
     }
 
-    if (*cnt < 1) {
-        return -1;
-    }
-
     switch (idx) {
     case FLASH_AREA_IMAGE_0:
-        off = FLASH_AREA_IMAGE_0_OFFSET;
-        len = FLASH_AREA_IMAGE_0_SIZE;
+        *off = FLASH_AREA_IMAGE_0_OFFSET;
+        *len = FLASH_AREA_IMAGE_0_SIZE;
         break;
     case FLASH_AREA_IMAGE_1:
-        off = FLASH_AREA_IMAGE_1_OFFSET;
-        len = FLASH_AREA_IMAGE_1_SIZE;
+        *off = FLASH_AREA_IMAGE_1_OFFSET;
+        *len = FLASH_AREA_IMAGE_1_SIZE;
         break;
     case FLASH_AREA_IMAGE_SCRATCH:
-        off = FLASH_AREA_IMAGE_SCRATCH_OFFSET;
-        len = FLASH_AREA_IMAGE_SCRATCH_SIZE;
+        *off = FLASH_AREA_IMAGE_SCRATCH_OFFSET;
+        *len = FLASH_AREA_IMAGE_SCRATCH_SIZE;
         break;
     default:
         BOOT_LOG_ERR("unknown flash area %d", idx);
@@ -199,7 +184,24 @@ int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
     }
 
     BOOT_LOG_DBG("area %d: offset=0x%x, length=0x%x, sector size=0x%x",
-             idx, off, len, FLASH_AREA_IMAGE_SECTOR_SIZE);
+                 idx, *off, *len, FLASH_AREA_IMAGE_SECTOR_SIZE);
+    return 0;
+}
+
+int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
+{
+    uint32_t off;
+    uint32_t len;
+    uint32_t max_cnt = *cnt;
+    uint32_t rem_len;
+
+    if (validate_idx(idx, &off, &len)) {
+        return -1;
+    }
+
+    if (*cnt < 1) {
+        return -1;
+    }
 
     rem_len = len;
     *cnt = 0;
@@ -215,6 +217,50 @@ int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
         ret[*cnt].pad16 = 0;
         ret[*cnt].fa_off = off + (FLASH_AREA_IMAGE_SECTOR_SIZE * (*cnt));
         ret[*cnt].fa_size = FLASH_AREA_IMAGE_SECTOR_SIZE;
+        *cnt = *cnt + 1;
+        rem_len -= FLASH_AREA_IMAGE_SECTOR_SIZE;
+    }
+
+    if (*cnt >= max_cnt) {
+        BOOT_LOG_ERR("flash area %d sector count overflow", idx);
+        return -1;
+    }
+
+    return 0;
+}
+
+/*
+ * Lookup the sector map for a given flash area.  This should fill in
+ * `ret` with all of the sectors in the area.  `*cnt` will be set to
+ * the storage at `ret` and should be set to the final number of
+ * sectors in this area.
+ */
+int flash_area_get_sectors(int idx, uint32_t *cnt, struct flash_sector *ret)
+{
+    uint32_t off;
+    uint32_t len;
+    uint32_t max_cnt = *cnt;
+    uint32_t rem_len;
+
+    if (validate_idx(idx, &off, &len)) {
+        return -1;
+    }
+
+    if (*cnt < 1) {
+        return -1;
+    }
+
+    rem_len = len;
+    *cnt = 0;
+    while (rem_len > 0 && *cnt < max_cnt) {
+        if (rem_len < FLASH_AREA_IMAGE_SECTOR_SIZE) {
+            BOOT_LOG_ERR("area %d size 0x%x not divisible by sector size 0x%x",
+                         idx, len, FLASH_AREA_IMAGE_SECTOR_SIZE);
+            return -1;
+        }
+
+        ret[*cnt].fs_off = FLASH_AREA_IMAGE_SECTOR_SIZE * (*cnt);
+        ret[*cnt].fs_size = FLASH_AREA_IMAGE_SECTOR_SIZE;
         *cnt = *cnt + 1;
         rem_len -= FLASH_AREA_IMAGE_SECTOR_SIZE;
     }

--- a/boot/zephyr/flash_map.c
+++ b/boot/zephyr/flash_map.c
@@ -32,26 +32,49 @@
 extern struct device *boot_flash_device;
 
 /*
+ * For now, we only support one flash device.
+ *
+ * Pick a random device ID for it that's unlikely to collide with
+ * anything "real".
+ */
+#define FLASH_DEVICE_ID 100
+#define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
+
+/*
  * The flash area describes essentially the partition table of the
  * flash.  In this case, it starts with FLASH_AREA_IMAGE_0.
  */
 static const struct flash_area part_map[] = {
     {
         .fa_id = FLASH_AREA_IMAGE_0,
+        .fa_device_id = FLASH_DEVICE_ID,
         .fa_off = FLASH_AREA_IMAGE_0_OFFSET,
         .fa_size = FLASH_AREA_IMAGE_0_SIZE,
     },
     {
         .fa_id = FLASH_AREA_IMAGE_1,
+        .fa_device_id = FLASH_DEVICE_ID,
         .fa_off = FLASH_AREA_IMAGE_1_OFFSET,
         .fa_size = FLASH_AREA_IMAGE_1_SIZE,
     },
     {
         .fa_id = FLASH_AREA_IMAGE_SCRATCH,
+        .fa_device_id = FLASH_DEVICE_ID,
         .fa_off = FLASH_AREA_IMAGE_SCRATCH_OFFSET,
         .fa_size = FLASH_AREA_IMAGE_SCRATCH_SIZE,
     },
 };
+
+int flash_device_base(uint8_t fd_id, uintptr_t *ret)
+{
+    if (fd_id != FLASH_DEVICE_ID) {
+        BOOT_LOG_ERR("invalid flash ID %d; expected %d",
+                     fd_id, FLASH_DEVICE_ID);
+        return -EINVAL;
+    }
+    *ret = FLASH_DEVICE_BASE;
+    return 0;
+}
 
 /*
  * `open` a flash area.  The `area` in this case is not the individual

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -43,11 +43,35 @@ extern "C" {
  */
 #include <inttypes.h>
 
+/**
+ * @brief Structure describing an area on a flash device.
+ *
+ * Multiple flash devices may be available in the system, each of
+ * which may have its own areas. For this reason, flash areas track
+ * which flash device they are part of.
+ */
 struct flash_area {
+    /**
+     * This flash area's ID; unique in the system.
+     */
     uint8_t fa_id;
+
+    /**
+     * ID of the flash device this area is a part of.
+     */
     uint8_t fa_device_id;
+
     uint16_t pad16;
+
+    /**
+     * This area's offset, relative to the beginning of its flash
+     * device's storage.
+     */
     uint32_t fa_off;
+
+    /**
+     * This area's size, in bytes.
+     */
     uint32_t fa_size;
 };
 

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -76,6 +76,16 @@ struct flash_area {
 };
 
 /*
+ * Retrieve a memory-mapped flash device's base address.
+ *
+ * On success, the address will be stored in the value pointed to by
+ * ret.
+ *
+ * Returns 0 on success, or an error code on failure.
+ */
+int flash_device_base(uint8_t fd_id, uintptr_t *ret);
+
+/*
  * Start using flash area.
  */
 int flash_area_open(uint8_t id, const struct flash_area **);

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -75,6 +75,25 @@ struct flash_area {
     uint32_t fa_size;
 };
 
+/**
+ * @brief Structure describing a sector within a flash area.
+ *
+ * Each sector has an offset relative to the start of its flash area
+ * (NOT relative to the start of its flash device), and a size. A
+ * flash area may contain sectors with different sizes.
+ */
+struct flash_sector {
+    /**
+     * Offset of this sector, from the start of its flash area (not device).
+     */
+    uint32_t fs_off;
+
+    /**
+     * Size of this sector, in bytes.
+     */
+    uint32_t fs_size;
+};
+
 /*
  * Retrieve a memory-mapped flash device's base address.
  *
@@ -107,8 +126,16 @@ int flash_area_erase(const struct flash_area *, uint32_t off, uint32_t len);
 uint8_t flash_area_align(const struct flash_area *);
 
 /*
- * Given flash map index, return info about sectors within the area.
+ * Given flash area ID, return info about sectors within the area.
  */
+int flash_area_get_sectors(int fa_id, uint32_t *count,
+  struct flash_sector *sectors);
+
+/*
+ * Similar to flash_area_get_sectors(), but return the values in an
+ * array of struct flash_area instead.
+ */
+__attribute__((deprecated))
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);
 
 int flash_area_id_from_image_slot(int slot);

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <assert.h>
 #include <zephyr.h>
 #include <flash.h>
 #include <asm_inline.h>
@@ -25,6 +26,7 @@
 #include "bootutil/bootutil_log.h"
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"
+#include "flash_map/flash_map.h"
 
 struct device *boot_flash_device;
 
@@ -39,13 +41,19 @@ struct arm_vector_table {
 static void do_boot(struct boot_rsp *rsp)
 {
     struct arm_vector_table *vt;
+    uintptr_t flash_base;
+    int rc;
 
     /* The beginning of the image is the ARM vector table, containing
      * the initial stack pointer address and the reset vector
      * consecutively. Manually set the stack pointer and jump into the
      * reset vector
      */
-    vt = (struct arm_vector_table *)(rsp->br_image_off +
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    assert(rc == 0);
+
+    vt = (struct arm_vector_table *)(flash_base +
+                                     rsp->br_image_off +
                                      rsp->br_hdr->ih_hdr_size);
     irq_lock();
     sys_clock_disable();
@@ -59,9 +67,15 @@ static void do_boot(struct boot_rsp *rsp)
  */
 static void do_boot(struct boot_rsp *rsp)
 {
+    uintptr_t flash_base;
     void *start;
+    int rc;
 
-    start = (void *)(rsp->br_image_off + rsp->br_hdr->ih_hdr_size);
+    rc = flash_device_base(rsp->br_flash_dev_id, &flash_base);
+    assert(rc == 0);
+
+    start = (void *)(flash_base + rsp->br_image_off +
+                     rsp->br_hdr->ih_hdr_size);
 
     /* Lock interrupts and dive into the entry point */
     irq_lock();

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -38,6 +38,8 @@ struct arm_vector_table {
     uint32_t reset;
 };
 
+extern void zephyr_flash_area_warn_on_open(void);
+
 static void do_boot(struct boot_rsp *rsp)
 {
     struct arm_vector_table *vt;
@@ -108,6 +110,7 @@ void main(void)
 
     BOOT_LOG_INF("Bootloader chainload address offset: 0x%x",
                  rsp.br_image_off);
+    zephyr_flash_area_warn_on_open();
     BOOT_LOG_INF("Jumping to the first image slot");
     do_boot(&rsp);
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -45,7 +45,7 @@ static void do_boot(struct boot_rsp *rsp)
      * consecutively. Manually set the stack pointer and jump into the
      * reset vector
      */
-    vt = (struct arm_vector_table *)(rsp->br_image_addr +
+    vt = (struct arm_vector_table *)(rsp->br_image_off +
                                      rsp->br_hdr->ih_hdr_size);
     irq_lock();
     sys_clock_disable();
@@ -61,7 +61,7 @@ static void do_boot(struct boot_rsp *rsp)
 {
     void *start;
 
-    start = (void *)(rsp->br_image_addr + rsp->br_hdr->ih_hdr_size);
+    start = (void *)(rsp->br_image_off + rsp->br_hdr->ih_hdr_size);
 
     /* Lock interrupts and dive into the entry point */
     irq_lock();
@@ -92,7 +92,8 @@ void main(void)
             ;
     }
 
-    BOOT_LOG_INF("Bootloader chainload address: 0x%x", rsp.br_image_addr);
+    BOOT_LOG_INF("Bootloader chainload address offset: 0x%x",
+                 rsp.br_image_off);
     BOOT_LOG_INF("Jumping to the first image slot");
     do_boot(&rsp);
 

--- a/sim/build.rs
+++ b/sim/build.rs
@@ -19,6 +19,7 @@ fn main() {
     conf.flag("-Wall");
     conf.define("__BOOTSIM__", None);
     // conf.define("MCUBOOT_OVERWRITE_ONLY", None);
+    conf.define("MCUBOOT_USE_FLASH_AREA_GET_SECTORS", None);
     conf.compile("libbootutil.a");
     walk_dir("../boot").unwrap();
     walk_dir("csupport").unwrap();

--- a/sim/csupport/run.c
+++ b/sim/csupport/run.c
@@ -52,7 +52,7 @@ int invoke_boot_go(void *flash, struct area_desc *adesc)
 	flash_areas = adesc;
 	if (setjmp(boot_jmpbuf) == 0) {
 		res = boot_go(&rsp);
-		/* printf("boot_go result: %d (0x%08x)\n", res, rsp.br_image_addr); */
+		/* printf("boot_go off: %d (0x%08x)\n", res, rsp.br_image_off); */
 		return res;
 	} else {
 		return -0x13579;

--- a/sim/csupport/run.c
+++ b/sim/csupport/run.c
@@ -188,6 +188,37 @@ int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
 	return 0;
 }
 
+int flash_area_get_sectors(int fa_id, uint32_t *count,
+                           struct flash_sector *sectors)
+{
+        int i;
+        struct area *slot;
+
+        for (i = 0; i < flash_areas->num_slots; i++) {
+                if (flash_areas->slots[i].id == fa_id)
+                        break;
+        }
+        if (i == flash_areas->num_slots) {
+                printf("Unsupported area\n");
+                abort();
+        }
+
+        slot = &flash_areas->slots[i];
+
+        if (slot->num_areas > *count) {
+                printf("Too many areas in slot\n");
+                abort();
+        }
+
+        for (i = 0; i < slot->num_areas; i++) {
+                sectors[i].fs_off = slot->areas[i].fa_off -
+                        slot->whole.fa_off;
+                sectors[i].fs_size = slot->areas[i].fa_size;
+        }
+        *count = slot->num_areas;
+
+        return 0;
+}
 
 int bootutil_img_validate(struct image_header *hdr,
                           const struct flash_area *fap,


### PR DESCRIPTION
This is basically a rewrite of the changes previously merged and then reverted in https://github.com/runtimeco/mcuboot/pull/49.

It gets us 99% of the way to resolving MCUB-54. The remaining portions require an out of tree series of patches in Zephyr to be merged (https://github.com/zephyrproject-rtos/zephyr/pull/205).

The main fix is to introduce, and then use, flash_device_base(). However, while we're changing API that mynewt also uses, I take the opportunity to add flash_area_get_sectors() and deprecate flash_area_to_sectors().

@d3zd3z, this switches to the new flash API by default in the simulator.

@mkiiskila, this should be even better for mynewt: you can take your time and implement flash_device_base() and flash_area_get_sectors() whenever you want. I have left a default implementation of flash_device_base() for mynewt that keeps existing behavior for now, and leave flash_area_to_sectors() as the default in the bootloader as well.

(Zephyr targets use 'real' versions of both).

@jamike, this series plus the Zephyr series I posted above should get you going on STM32F4. You need to change prj.conf in mcuboot to allow flash writes as well.