### PR TITLE
Fixes trying to close an invalid flash map handle

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -745,8 +745,12 @@ boot_copy_sector(int flash_area_id_src, int flash_area_id_dst,
     rc = 0;
 
 done:
-    flash_area_close(fap_src);
-    flash_area_close(fap_dst);
+    if (fap_src) {
+        flash_area_close(fap_src);
+    }
+    if (fap_dst) {
+        flash_area_close(fap_dst);
+    }
     return rc;
 }
 

--- a/boot/zephyr/flash_map.c
+++ b/boot/zephyr/flash_map.c
@@ -122,8 +122,13 @@ int flash_area_open(uint8_t id, const struct flash_area **area)
  */
 void flash_area_close(const struct flash_area *area)
 {
-    struct flash_map_entry *entry = CONTAINER_OF(area, struct flash_map_entry,
-                                                 area);
+    struct flash_map_entry *entry;
+
+    if (!area) {
+        return;
+    }
+
+    entry = CONTAINER_OF(area, struct flash_map_entry, area);
     if (entry->magic != FLASH_MAP_ENTRY_MAGIC) {
         BOOT_LOG_ERR("invalid area %p (id %u)", area, area->fa_id);
         return;


### PR DESCRIPTION
This error was catched by Coverity and it happens when a fail occurs
opening a flash map handle, which is not checked by the close
routine.

Right now this only affects Zephyr, but extra checking was added
assuming that in a future Mynewt implementation close could actually
be changed to do something.

Signed-off-by: Fabio Utzig <utzig@apache.org>