### PR TITLE
New trailer format

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -40,6 +40,9 @@ extern "C" {
 
 #define BOOT_SWAP_TYPE_FAIL     0xff
 
+#define MAX_FLASH_ALIGN         8
+extern const uint32_t BOOT_MAX_ALIGN;
+
 struct image_header;
 /**
  * A response object provided by the boot loader code; indicates where to jump
@@ -55,6 +58,17 @@ struct boot_rsp {
      */
     uint8_t br_flash_dev_id;
     uint32_t br_image_off;
+};
+
+/* This is not actually used by mcuboot's code but can be used by apps
+ * when attempting to read/write a trailer.
+ */
+struct image_trailer {
+    uint8_t copy_done;
+    uint8_t pad1[MAX_FLASH_ALIGN - 1];
+    uint8_t image_ok;
+    uint8_t pad2[MAX_FLASH_ALIGN - 1];
+    uint8_t magic[16];
 };
 
 /* you must have pre-allocated all the entries within this structure */

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -40,8 +40,6 @@ struct flash_area;
 
 #define BOOT_TMPBUF_SZ  256
 
-#define BOOT_MAX_ALIGN  8
-
 /*
  * Maintain state of copy progress.
  */

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -471,7 +471,7 @@ boot_write_status(struct boot_status *bs)
     uint32_t off;
     int area_id;
     int rc;
-    uint8_t buf[8];
+    uint8_t buf[BOOT_MAX_ALIGN];
     uint8_t align;
 
     /* NOTE: The first sector copied (that is the last sector on slot) contains
@@ -498,7 +498,7 @@ boot_write_status(struct boot_status *bs)
                                    BOOT_WRITE_SZ(&boot_data));
 
     align = hal_flash_align(fap->fa_device_id);
-    memset(buf, 0xFF, 8);
+    memset(buf, 0xFF, BOOT_MAX_ALIGN);
     buf[0] = bs->state;
 
     rc = flash_area_write(fap, off, buf, align);
@@ -941,7 +941,7 @@ boot_swap_sectors(int idx, uint32_t sz, struct boot_status *bs)
             /* copy current status that is being maintained in scratch */
             rc = boot_copy_sector(FLASH_AREA_IMAGE_SCRATCH, FLASH_AREA_IMAGE_0,
                         scratch_trailer_off,
-                        img_off + copy_sz + BOOT_MAGIC_SZ,
+                        img_off + copy_sz,
                         BOOT_STATUS_STATE_COUNT * BOOT_WRITE_SZ(&boot_data));
             assert(rc == 0);
 

--- a/scripts/imgtool.py
+++ b/scripts/imgtool.py
@@ -29,7 +29,6 @@ def do_getpub(args):
     key.emit_c()
 
 def do_sign(args):
-    align = args.align
     if args.rsa_pkcs1_15:
         keys.sign_rsa_pss = False
     img = image.Image.load(args.infile, version=args.version,

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -27,12 +27,11 @@ TLV_VALUES = {
 
 TLV_HEADER_SIZE = 4
 
-# Sizes of the image trailer, depending on image alignment.
+# Sizes of the image trailer, depending on flash write size.
 trailer_sizes = {
-        1: 402,
-        2: 788,
-        4: 1560,
-        8: 3104, }
+    write_size: 128 * 3 * write_size + 8 * 2 + 16
+    for write_size in [1, 2, 4, 8]
+}
 
 boot_magic = bytes([
     0x77, 0xc2, 0x95, 0xf3,
@@ -166,7 +165,7 @@ class Image():
             msg = "Image size (0x{:x}) + trailer (0x{:x}) exceeds requested size 0x{:x}".format(
                     len(self.payload), tsize, size)
             raise Exception(msg)
-        pbytes = b'\xff' * padding
-        pbytes += boot_magic
+        pbytes  = b'\xff' * padding
         pbytes += b'\xff' * (tsize - len(boot_magic))
+        pbytes += boot_magic
         self.payload += pbytes

--- a/sim/src/c.rs
+++ b/sim/src/c.rs
@@ -33,6 +33,14 @@ pub fn set_sim_flash_align(align: u8) {
     unsafe { raw::sim_flash_align = align };
 }
 
+pub fn boot_magic_sz() -> usize {
+    unsafe { raw::BOOT_MAGIC_SZ as usize }
+}
+
+pub fn boot_max_align() -> usize {
+    unsafe { raw::BOOT_MAX_ALIGN as usize }
+}
+
 mod raw {
     use area::CAreaDesc;
     use libc;
@@ -46,5 +54,8 @@ mod raw {
 
         pub static mut sim_flash_align: u8;
         pub fn boot_slots_trailer_sz(min_write_sz: u8) -> u32;
+
+        pub static BOOT_MAGIC_SZ: u32;
+        pub static BOOT_MAX_ALIGN: u32;
     }
 }

--- a/sim/src/flash.rs
+++ b/sim/src/flash.rs
@@ -107,7 +107,8 @@ impl Flash {
 
         for (i, x) in &mut self.write_safe[offset .. offset + payload.len()].iter_mut().enumerate() {
             if !(*x) {
-                bail!(ewrite(format!("Write to unerased location at 0x{:x}", i)));
+                bail!(ewrite(format!("Write to unerased location at 0x{:x}",
+                                     offset + i)));
             }
             *x = false;
         }


### PR DESCRIPTION
This implements issue MCUB-14.

Trailer was updated with magic moved to the end and flags now are 8 bytes no matter which is the flash write size. This makes it easier to write external apps the can read/write this data without having the get extra info from the bootloader itself.