### PR TITLE
Always validate slot 0 when requested

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1249,14 +1249,6 @@ boot_go(struct boot_rsp *rsp)
 
     switch (swap_type) {
     case BOOT_SWAP_TYPE_NONE:
-#ifdef MCUBOOT_VALIDATE_SLOT0
-        rc = boot_validate_slot(0);
-        assert(rc == 0);
-        if (rc != 0) {
-            rc = BOOT_EBADIMAGE;
-            goto out;
-        }
-#endif
         slot = 0;
         break;
 
@@ -1285,6 +1277,15 @@ boot_go(struct boot_rsp *rsp)
         slot = 0;
         break;
     }
+
+#ifdef MCUBOOT_VALIDATE_SLOT0
+    rc = boot_validate_slot(0);
+    assert(rc == 0);
+    if (rc != 0) {
+        rc = BOOT_EBADIMAGE;
+        goto out;
+    }
+#endif
 
     /* Always boot from the primary slot. */
     rsp->br_flash_dev_id = boot_img_fa_device_id(&boot_data, 0);

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -24,6 +24,7 @@
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdbool.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1201,6 +1202,7 @@ boot_go(struct boot_rsp *rsp)
     size_t slot;
     int rc;
     int fa_id;
+    bool reload_headers = false;
 
     /* The array of slot sectors are defined here (as opposed to file scope) so
      * that they don't get allocated for non-boot-loader apps.  This is
@@ -1256,11 +1258,13 @@ boot_go(struct boot_rsp *rsp)
     case BOOT_SWAP_TYPE_PERM:
         slot = 1;
         boot_finalize_test_swap();
+        reload_headers = true;
         break;
 
     case BOOT_SWAP_TYPE_REVERT:
         slot = 1;
         boot_finalize_revert_swap();
+        reload_headers = true;
         break;
 
     case BOOT_SWAP_TYPE_FAIL:
@@ -1270,6 +1274,7 @@ boot_go(struct boot_rsp *rsp)
          */
         slot = 0;
         boot_finalize_revert_swap();
+        reload_headers = true;
         break;
 
     default:
@@ -1279,6 +1284,13 @@ boot_go(struct boot_rsp *rsp)
     }
 
 #ifdef MCUBOOT_VALIDATE_SLOT0
+    if (reload_headers) {
+            rc = boot_read_image_headers();
+            if (rc != 0) {
+                    goto out;
+            }
+    }
+
     rc = boot_validate_slot(0);
     assert(rc == 0);
     if (rc != 0) {


### PR DESCRIPTION
The MCUBOOT_VALIDATE_SLOT0 feature only verifies the signature when
there is no swapping happening.  The assumption was that if there is a
swap being done, the code will verify the signature of slot 1 before
doing the slot.

However, either due to bugs, or intentional trickery, it may be possible
to confuse the code into continuing a swap operation.  If the data is
modified before this, the bootloader can be tricked into booting the
resulting image in slot 0 without having verified the signature.

Fix this by always verifying slot 0's signature before booting it.

JIRA: MCUB-64
Signed-off-by: David Brown <david.brown@linaro.org>