### PR TITLE
This add support for mynewt resigned images

### DIFF
--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -108,6 +108,9 @@ bootutil_img_validate(struct image_header *hdr, const struct flash_area *fap,
     uint8_t buf[256];
     uint8_t hash[32];
     int rc;
+#ifdef APP_mynewt
+    int i;
+#endif
 
 #ifdef MCUBOOT_SIGN_RSA
 #ifdef MCUBOOT_RSA_PKCS1_15
@@ -216,10 +219,19 @@ bootutil_img_validate(struct image_header *hdr, const struct flash_area *fap,
         return -1;
     }
 
+#ifndef APP_mynewt
     if (hdr->ih_key_id >= bootutil_key_cnt) {
         return -1;
     }
     rc = bootutil_verify_sig(hash, sizeof(hash), buf, sig_len, hdr->ih_key_id);
+#else
+    for (i = 0; i < bootutil_key_cnt; i++) {
+        rc = bootutil_verify_sig(hash, sizeof(hash), buf, sig_len, i);
+        if (!rc) {
+            break;
+        }
+    }
+#endif
     if (rc) {
         return -1;
     }


### PR DESCRIPTION
`newt` accepts a parameter for the keyid which can be any u8
value. This means that for mynewt keyid is not an index and
the only way to validate the image is to try every key and
fail only if none validates.

Implements MCUB-65.

Signed-off-by: Fabio Utzig <utzig@apache.org>