### PR TITLE
sim: Update doc to explain submodules

### DIFF
--- a/sim/README.rst
+++ b/sim/README.rst
@@ -16,6 +16,16 @@ simulator can be built with the stable release of Rust.
 
 .. _installation: https://www.rust-lang.org/en-US/install.html
 
+Dependent code
+--------------
+
+The simulator depends on some external modules.  These are stored as
+submodules within git.  To fetch these dependencies the first time::
+
+  $ git submodule update --init
+
+will clone and check out these trees in the appropriate place.
+
 Building
 ========
 


### PR DESCRIPTION
Now that we depend on a submodule for mbed TLS code, update the docs to
explain how to fetch this.  Otherwise, the error is somewhat misleading,
just showing a missing sha256.c file.

Signed-off-by: David Brown <david.brown@linaro.org>