### PR TITLE
Remove incubator references from mynewt dev email

### DIFF
--- a/boot/boot_serial/pkg.yml
+++ b/boot/boot_serial/pkg.yml
@@ -19,7 +19,7 @@
 
 pkg.name: boot/boot_serial
 pkg.description: The boot_serial library is used when downloading image over serial port.
-pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - boot

--- a/boot/boot_serial/test/pkg.yml
+++ b/boot/boot_serial/test/pkg.yml
@@ -18,7 +18,7 @@
 pkg.name: boot/boot_serial/test
 pkg.type: unittest
 pkg.description: "Boot serial unit tests."
-pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 

--- a/boot/bootutil/pkg.yml
+++ b/boot/bootutil/pkg.yml
@@ -19,7 +19,7 @@
 
 pkg.name: boot/bootutil
 pkg.description: The bootutil library performs most of the functions of a boot loader.
-pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - boot

--- a/boot/bootutil/test/pkg.yml
+++ b/boot/bootutil/test/pkg.yml
@@ -18,7 +18,7 @@
 pkg.name: boot/bootutil/test
 pkg.type: unittest
 pkg.description: "Bootutil unit tests."
-pkg.author: "Apache Mynewt <dev@mynewt.incubator.apache.org>"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 

--- a/boot/mynewt/pkg.yml
+++ b/boot/mynewt/pkg.yml
@@ -20,7 +20,7 @@
 pkg.name: boot/mynewt
 pkg.type: app
 pkg.description: "Mynewt port of mcuboot"
-pkg.author: "Fabio Utzig <utzig@apache.org>"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - loader


### PR DESCRIPTION
Also use a single email for all packages.

Signed-off-by: Fabio Utzig <utzig@apache.org>