### PR TITLE
Fix newtmgr

### DIFF
--- a/README-mynewt.rst
+++ b/README-mynewt.rst
@@ -1,0 +1,33 @@
+Running mynewt apps with mcuboot
+################################
+
+Due to small differences between Mynewt's bundled bootloader and **mcuboot**,
+when building an app that will be run with **mcuboot** as the bootloader and
+which at the same time requires to use **newtmgr** to manage images, **mcuboot**
+must be added as a new dependency for this app.
+
+First you need to add the repo to your ``project.yml``:
+
+.. code-block:: yaml
+
+    project.repositories:
+        - mcuboot
+
+    repository.mcuboot:
+        type: github
+        vers: 0-dev
+        user: runtimeco
+        repo: mcuboot
+
+Then update your app's ``pkg.yml`` adding the extra dependency:
+
+.. code-block:: yaml
+
+    pkg.deps:
+        - "@mcuboot/boot/bootutil"
+
+Also remove any dependency on ``boot/bootutil`` (mynewt's bundled bootloader)
+which might exist.
+
+To configure **mcuboot** check all the options available in
+``boot/mynewt/mcuboot_config/syscfg.yml``.

--- a/boot/bootutil/include/bootutil/sha256.h
+++ b/boot/bootutil/include/bootutil/sha256.h
@@ -29,12 +29,8 @@
 #ifndef __BOOTUTIL_CRYPTO_H_
 #define __BOOTUTIL_CRYPTO_H_
 
-/* FIXME: The test below will only work as long as the app name is
- * "mynewt", building for mynewt could export some __linux__, __APPLE__
- * style macro!
- */
-#ifdef APP_mynewt
-#include "mynewt/config.h"
+#ifdef MCUBOOT_MYNEWT
+#include "mcuboot_config/mcuboot_config.h"
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS) && defined(MCUBOOT_USE_TINYCRYPT)

--- a/boot/bootutil/pkg.yml
+++ b/boot/bootutil/pkg.yml
@@ -25,7 +25,14 @@ pkg.keywords:
     - boot
     - bootloader
 
+pkg.apis:
+    - bootloader
+
+pkg.cflags:
+    - "-DMCUBOOT_MYNEWT"
+
 pkg.deps:
+    - "@mcuboot/boot/mynewt/mcuboot_config"
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/crypto/mbedtls"
     - "@apache-mynewt-core/kernel/os"

--- a/boot/bootutil/src/image_ec.c
+++ b/boot/bootutil/src/image_ec.c
@@ -19,8 +19,8 @@
 
 #include <string.h>
 
-#ifdef APP_mynewt
-#include "mynewt/config.h"
+#ifdef MCUBOOT_MYNEWT
+#include "mcuboot_config/mcuboot_config.h"
 #endif
 
 #ifdef MCUBOOT_SIGN_EC

--- a/boot/bootutil/src/image_ec256.c
+++ b/boot/bootutil/src/image_ec256.c
@@ -19,8 +19,8 @@
 
 #include <string.h>
 
-#ifdef APP_mynewt
-#include "mynewt/config.h"
+#ifdef MCUBOOT_MYNEWT
+#include "mcuboot_config/mcuboot_config.h"
 #endif
 
 #ifdef MCUBOOT_SIGN_EC256

--- a/boot/bootutil/src/image_rsa.c
+++ b/boot/bootutil/src/image_rsa.c
@@ -19,8 +19,8 @@
 
 #include <string.h>
 
-#ifdef APP_mynewt
-#include "mynewt/config.h"
+#ifdef MCUBOOT_MYNEWT
+#include "mcuboot_config/mcuboot_config.h"
 #endif
 
 #ifdef MCUBOOT_SIGN_RSA

--- a/boot/bootutil/src/image_validate.c
+++ b/boot/bootutil/src/image_validate.c
@@ -28,8 +28,8 @@
 #include "bootutil/sha256.h"
 #include "bootutil/sign_key.h"
 
-#ifdef APP_mynewt
-#include "mynewt/config.h"
+#ifdef MCUBOOT_MYNEWT
+#include "mcuboot_config/mcuboot_config.h"
 #endif
 
 #ifdef MCUBOOT_SIGN_RSA

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -37,8 +37,8 @@
 #define BOOT_LOG_LEVEL BOOT_LOG_LEVEL_INFO
 #include "bootutil/bootutil_log.h"
 
-#ifdef APP_mynewt
-#include "mynewt/config.h"
+#ifdef MCUBOOT_MYNEWT
+#include "mcuboot_config/mcuboot_config.h"
 #endif
 
 static struct boot_loader_state boot_data;

--- a/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef __BOOT_CONFIG_H__
-#define __BOOT_CONFIG_H__
+#ifndef __MCUBOOT_CONFIG_H__
+#define __MCUBOOT_CONFIG_H__
 
-#include "syscfg/syscfg.h"
+#include <syscfg/syscfg.h>
 
 #if MYNEWT_VAL(BOOT_SERIAL)
 #define MCUBOOT_SERIAL 1
@@ -49,4 +49,4 @@
 #define MCUBOOT_OVERWRITE_ONLY 1
 #endif
 
-#endif /* __BOOT_CONFIG_H__ */
+#endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/mynewt/mcuboot_config/pkg.yml
+++ b/boot/mynewt/mcuboot_config/pkg.yml
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,17 +17,7 @@
 # under the License.
 #
 
-# Package: boot/mynewt
-
-syscfg.defs:
-    BOOT_LOADER:
-        description: 'Set to indicate that this app is a bootloader.'
-        value: 1
-    BOOT_SERIAL:
-        description: 'Support image upgrade over serial within bootloader'
-        value: 0
-
-syscfg.vals:
-    SYSINIT_CONSTRAIN_INIT: 0
-    OS_SCHEDULING: 0
-    OS_CPUTIME_TIMER_NUM: -1
+pkg.name: boot/mynewt/mcuboot_config
+pkg.description: "Mynewt's mcuboot configuration"
+pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
+pkg.homepage: "http://mynewt.apache.org/"

--- a/boot/mynewt/mcuboot_config/syscfg.yml
+++ b/boot/mynewt/mcuboot_config/syscfg.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Package: boot/mynewt/mcuboot_config
+
+syscfg.defs:
+    BOOTUTIL_VALIDATE_SLOT0:
+        description: 'Validate image at slot 0 on each boot.'
+        value: 0
+    BOOTUTIL_SIGN_RSA:
+        description: 'Images are signed using RSA2048.'
+        value: 0
+    BOOTUTIL_RSA_PKCS1_15:
+        description: 'Sign using old PKCS#1 1.5 (otherwise uses PSS)'
+        value: 0
+    BOOTUTIL_SIGN_EC:
+        description: 'Images are signed using ECDSA NIST P-224.'
+        value: 0
+    BOOTUTIL_SIGN_EC256:
+        description: 'Images are signed using ECDSA NIST P-256.'
+        value: 0
+    BOOTUTIL_USE_MBED_TLS:
+        description: 'Use mbed TLS for crypto operations.'
+        value: 1
+    BOOTUTIL_USE_TINYCRYPT:
+        description: 'Use tinycrypt for crypto operations.'
+        value: 0
+    BOOTUTIL_OVERWRITE_ONLY:
+        description: 'Non-swapping upgrades, copy from slot 1 to slot 0 only.'
+        value: 0

--- a/boot/mynewt/pkg.yml
+++ b/boot/mynewt/pkg.yml
@@ -26,6 +26,7 @@ pkg.keywords:
     - loader
 
 pkg.deps:
+    - "@mcuboot/boot/mynewt/mcuboot_config"
     - "@mcuboot/boot/bootutil"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/stub"


### PR DESCRIPTION
This fixes `newtmgr` when building `mynewt` images to be run on `mcuboot`. README file also added.