### PR TITLE
Minor zephyr fixes in since rc1

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -12,6 +12,7 @@ CONFIG_MBEDTLS_CFG_FILE="config-boot.h"
 CONFIG_HEAP_MEM_POOL_SIZE=16384
 
 CONFIG_FLASH=y
+CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
 ### Disable Bluetooth by default
 # CONFIG_BLUETOOTH is not set

--- a/samples/zephyr/Makefile
+++ b/samples/zephyr/Makefile
@@ -142,6 +142,9 @@ flash_hello1:
 flash_hello2:
 	$(PYOCD_FLASHTOOL) -a 0x80000 signed-hello2.bin
 
+flash_full:
+	$(PYOCD_FLASHTOOL) -ce -a 0 full.bin
+
 check:
 	@if [ -z "$$ZEPHYR_BASE" ]; then echo "Zephyr environment not set up"; false; fi
 	@if [ -z "$(BOARD)" ]; then echo "You must specity BOARD=<board>"; false; fi


### PR DESCRIPTION
Two minor fixes. One to be able to flash the full.bin target. The other needed in recent Zephyr trees to allow writes to the flash device.