### PR TITLE
Fix names of Mynewt config options

### DIFF
--- a/doc/signed_images.md
+++ b/doc/signed_images.md
@@ -90,14 +90,15 @@ This exports the keys.
 
 ## Building bootloader
 
-Enable the MCUBOOT_SIGN_RSA syscfg setting in your app or target syscfg.yml
-file
+Enable the BOOTUTIL_SIGN_RSA and BOOTUTIL_RSA_PKCS1_15 syscfg settings in your
+app or target syscfg.yml file
 
     syscfg.vals:
-        MCUBOOT_SIGN_RSA: 1
+        BOOTUTIL_SIGN_RSA: 1
+        BOOTUTIL_RSA_PKCS1_15: 1
 
 After you've created the key package, you must include it in the build
 for bootloader. So modify the pkg.yml for apps/boot to include it.
 
-The syscfg variable to enable ECDSA224 is MCUBOOT_SIGN_EC, and
-MCUBOOT_SIGN_EC256 for ECDS256.
+The syscfg variable to enable ECDSA224 is BOOTUTIL_SIGN_EC, and
+BOOTUTIL_SIGN_EC256 for ECDS256.


### PR DESCRIPTION
Also documents config option to use PKCS#1 v1.5 as images generated by
newt.

Signed-off-by: Fabio Utzig <utzig@apache.org>