### PR TITLE
Design doc fixups

### DIFF
--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -32,7 +32,7 @@ extern "C" {
 /** Swap to slot 1.  Absent a confirm command, revert back on next boot. */
 #define BOOT_SWAP_TYPE_TEST     2
 
-/** Swap to slot 1 permanently. */
+/** Swap to slot 1, and permanently switch to booting its contents. */
 #define BOOT_SWAP_TYPE_PERM     3
 
 /** Swap back to alternate slot.  A confirm changes this state to NONE. */

--- a/boot/bootutil/include/bootutil/bootutil.h
+++ b/boot/bootutil/include/bootutil/bootutil.h
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 
-/** Just boot whatever is in slot 0. */
+/** Attempt to boot the contents of slot 0. */
 #define BOOT_SWAP_TYPE_NONE     1
 
 /** Swap to slot 1.  Absent a confirm command, revert back on next boot. */

--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -36,13 +36,13 @@ struct flash_area;
 /*
  * Image header flags.
  */
-#define IMAGE_F_PIC                   0x00000001 /* Not currently supported. */
-#define IMAGE_F_SHA256                0x00000002 /* Image contains hash TLV */
-#define IMAGE_F_PKCS15_RSA2048_SHA256 0x00000004 /* PKCS15 w/RSA and SHA */
-#define IMAGE_F_ECDSA224_SHA256       0x00000008 /* ECDSA224 over SHA256 */
-#define IMAGE_F_NON_BOOTABLE          0x00000010 /* Split image app. */
-#define IMAGE_F_ECDSA256_SHA256       0x00000020 /* ECDSA256 over SHA256 */
-#define IMAGE_F_PKCS1_PSS_RSA2048_SHA256 0x0000040 /* PKCS1 PSS */
+#define IMAGE_F_PIC                      0x00000001 /* Not supported. */
+#define IMAGE_F_SHA256                   0x00000002 /* Hash TLV is present */
+#define IMAGE_F_PKCS15_RSA2048_SHA256    0x00000004 /* PKCS15 w/RSA and SHA */
+#define IMAGE_F_ECDSA224_SHA256          0x00000008 /* ECDSA224 over SHA256 */
+#define IMAGE_F_NON_BOOTABLE             0x00000010 /* Split image app. */
+#define IMAGE_F_ECDSA256_SHA256          0x00000020 /* ECDSA256 over SHA256 */
+#define IMAGE_F_PKCS1_PSS_RSA2048_SHA256 0x00000040 /* PKCS1 PSS */
 
 /*
  * ECSDA224 is with NIST P-224

--- a/doc/design.txt
+++ b/doc/design.txt
@@ -110,12 +110,15 @@ region of disk with the following properties:
     (1) An area can be fully erased without affecting any other areas.
     (2) A write to one area does not restrict writes to other areas.
 
-The boot loader uses the following flash areas:
+The boot loader uses the following flash area IDs:
 
 #define FLASH_AREA_BOOTLOADER                    0
 #define FLASH_AREA_IMAGE_0                       1
 #define FLASH_AREA_IMAGE_1                       2
 #define FLASH_AREA_IMAGE_SCRATCH                 3
+
+The bootloader area contains the bootloader image itself. The other areas are
+described in subsequent sections.
 
 *** IMAGE SLOTS
 

--- a/doc/design.txt
+++ b/doc/design.txt
@@ -141,78 +141,58 @@ even when it is reset during the middle of an image swap. For this reason, the
 rest of the document describes its behavior when configured to swap images
 during an upgrade.
 
-*** BOOT STATES
+*** BOOT SWAP TYPES
 
-Logically, you can think of a pair of values associated with each image slot:
-pending and confirmed.  On startup, the boot loader determines the state of the
-device by inspecting each pair of values.  These values have the following
-meanings:
+When the device first boots under normal circumstances, there is an up-to-date
+firmware image in slot 0, which mcuboot can validate and then chain-load. In
+this case, no image swaps are necessary. During device upgrades, however, new
+candidate images are present in slot 1, which mcuboot must swap into slot 0
+before booting as discussed above.
 
-* pending: Indicates whether the image should be used on the next reboot; can
-  hold one of three values:
-    " " (unset):     Don't use image on next boot
-    "T" (temporary): Use image on next boot; absent subsequent confirm command,
-                     revert to original image on second reboot.
-    "P" (permanent): Use image on next boot and all subsequent boots
+Upgrading an old image with a new one by swapping can be a two-step process. In
+this process, mcuboot performs a "test" swap of image data in flash and boots
+the new image. The new image can then update the contents of flash at runtime
+to mark itself "OK", and mcuboot will then still choose to run it during the
+next boot. When this happens, the swap is made "permanent". If this doesn't
+happen, mcuboot will perform a "revert" swap during the next boot by swapping
+the images back into their original locations, and attempting to boot the old
+image.
 
-* confirmed: always use image unless excluded by a test image.
+Depending on the use case, the first swap can also be made permanent directly.
+In this case, mcuboot will never attempt to revert the images on the next reset.
 
-In English, when the user wants to run the secondary image, they set the
-pending flag for the second slot and reboot the device.  On startup, the boot
-loader will swap the two images in flash, clear the secondary slot's pending
-flag, and run the newly-copied image in slot 0.  If the user set the pending
-flag to "temporary," then this is only a temporary state; if the device reboots
-again, the boot loader swaps the images back to their original slots and boots
-into the original image.  If the user doesn't want to revert to the original
-state, they can make the current state permanent by setting the confirmed flag
-in slot 0.
+Test swaps are supported to provide a rollback mechanism to prevent devices
+from becoming "bricked" by bad firmware.  If the device crashes immediately
+upon booting a new (bad) image, mcuboot will revert to the old (working) image
+at the next device reset, rather than booting the bad image again. This allows
+device firmware to make test swaps permanent only after performing a self-test
+routine.
 
-Switching to an alternate image is a two-step process (set + confirm) to
-prevent a device from becoming "bricked" by bad firmware.  If the device
-crashes immediately upon booting the second image, the boot loader reverts to
-the working image, rather than repeatedly rebooting into the bad image.
+On startup, mcuboot inspects the contents of flash to decide which of these
+"swap types" to perform; this decision determines how it proceeds.
 
-Alternatively, if the user is confident that the second image is good, they can
-set and confirm in a single action by setting the pending flag to "permanent."
+The possible swap types, and their meanings, are:
 
-The following set of tables illustrate the four possible states that the device
-can be in:
+- BOOT_SWAP_TYPE_NONE: The "usual" or "no upgrade" case; attempt to boot the
+  contents of slot 0.
 
-                   | slot-0 | slot-1 |
-    ---------------+--------+--------|
-           pending |        |        |
-         confirmed |   X    |        |
-    ---------------+--------+--------'
-    Image 0 confirmed;               |
-    No change on reboot              |
-    ---------------------------------'
+- BOOT_SWAP_TYPE_TEST: Boot the contents of slot 1 by swapping images. Unless
+  the swap is made permanent, revert back on the next boot.
 
-                   | slot-0 | slot-1 |
-    ---------------+--------+--------|
-           pending |        |   T    |
-         confirmed |   X    |        |
-    ---------------+--------+--------'
-    Image 0 confirmed;               |
-    Test image 1 on next reboot      |
-    ---------------------------------'
+- BOOT_SWAP_TYPE_PERM: Permanently swap images, and boot the upgraded image
+  firmware.
 
-                   | slot-0 | slot-1 |
-    ---------------+--------+--------|
-           pending |        |   P    |
-         confirmed |   X    |        |
-    ---------------+--------+--------'
-    Image 0 confirmed;               |
-    Use image 1 permanently on boot  |
-    ---------------------------------'
+- BOOT_SWAP_TYPE_REVERT: A previous test swap was not made permanent; swap back
+  to the old image whose data are now in slot 1.  If the old image marks itself
+  "OK" when it boots, the next boot will have swap type BOOT_SWAP_TYPE_NONE.
 
-                   | slot-0 | slot-1 |
-    ---------------+--------+--------|
-           pending |        |        |
-         confirmed |        |   X    |
-    ---------------+--------+--------'
-    Testing image 0;                 |
-    Revert to image 1 on next reboot |
-    ---------------------------------'
+- BOOT_SWAP_TYPE_FAIL: Swap failed because image to be run is not valid.
+
+- BOOT_SWAP_TYPE_PANIC: Swapping encountered an unrecoverable error.
+
+The "swap type" is a high-level representation of the outcome of the
+boot. Subsequent sections describe how mcuboot determines the swap type from
+the bit-level contents of flash.
 
 *** IMAGE TRAILER
 
@@ -281,18 +261,15 @@ confirmed as good by the user (0x01=confirmed; 0xff=not confirmed).
 
 *** IMAGE TRAILERS
 
-At startup, the boot loader determines which of the above four states the
-device is in by inspecting the image trailers.  When using the term "image
-trailers" what is meant is the aggregate information provided by both image
-slot's trailers.
+At startup, the boot loader determines the boot swap type by inspecting the
+image trailers.  When using the term "image trailers" what is meant is the
+aggregate information provided by both image slot's trailers.
 
 The image trailers records are structured around the limitations imposed by flash
 hardware.  As a consequence, they do not have a very intuitive design, and it
 is difficult to get a sense of the state of the device just by looking at the
-image trailers.  It is better to map all the possible trailer states to the four
-states described above via a set of tables.  These tables are reproduced below.
-In these tables, the "pending" and "confirmed" flags are shown for illustrative
-purposes; they are not actually present in the image trailers.
+image trailers.  It is better to map all the possible trailer states to the swap
+types described above via a set of tables.  These tables are reproduced below.
 
 Note: An important caveat about the tables described below is that they must
 be evaluated in the order presented here. Lower state numbers must have a
@@ -306,10 +283,7 @@ higher priority when testing the image trailers.
             image-ok | Any    | Unset  |
            copy-done | Any    | Any    |
     -----------------+--------+--------'
-             pending |        |   T    |
-          confirmed  |   X    |        |
-    -----------------+--------+--------'
-     swap: test                        |
+     result: BOOT_SWAP_TYPE_TEST       |
     -----------------------------------'
 
 
@@ -320,10 +294,7 @@ higher priority when testing the image trailers.
             image-ok | Any    | 0x01   |
            copy-done | Any    | Any    |
     -----------------+--------+--------'
-             pending |        |   P    |
-          confirmed  |   X    |        |
-    -----------------+--------+--------'
-     swap: permanent                   |
+     result: BOOT_SWAP_TYPE_PERM       |
     -----------------------------------'
 
 
@@ -334,17 +305,13 @@ higher priority when testing the image trailers.
             image-ok | 0xff   | Any    |
            copy-done | 0x01   | Any    |
     -----------------+--------+--------'
-             pending |        |        |
-          confirmed  |        |   X    |
-    -----------------+--------+--------'
-     swap: revert (test image running) |
+     result: BOOT_SWAP_TYPE_REVERT     |
     -----------------------------------'
 
+Any of the above three states results in mcuboot attempting to swap images.
 
-Those three states described above are explicity tested for and result in a
-swap decision by the bootloader. If the existing values in the the image trailers
-are not one of those previously described the bootloader will assume no swap
-operation is to be performed which is illustrated by state IV.
+Otherwise, mcuboot does not attempt to swap images, resulting in one of the
+other three swap types, as illustrated by State IV.
 
 
     State IV
@@ -354,24 +321,22 @@ operation is to be performed which is illustrated by state IV.
             image-ok | Any    | Any    |
            copy-done | Any    | Any    |
     -----------------+--------+--------'
-             pending |        |        |
-          confirmed  |   X    |        |
-    -----------------+--------+--------'
-     swap: none                        |
+     result: BOOT_SWAP_TYPE_NONE,      |
+             BOOT_SWAP_TYPE_FAIL, or   |
+             BOOT_SWAP_TYPE_PANIC      |
     -----------------------------------'
 
+In State IV, when no errors occur, mcuboot will attempt to boot the contents of
+slot 0 directly, and the result is BOOT_SWAP_TYPE_NONE. If the image in slot 0
+is not valid, the result is BOOT_SWAP_TYPE_FAIL. If a fatal error occurs during
+boot, the result is BOOT_SWAP_TYPE_PANIC. If the result is either
+BOOT_SWAP_TYPE_FAIL or BOOT_SWAP_TYPE_PANIC, mcuboot hangs rather than booting
+an invalid or compromised image.
 
-Note: An important caveat to be mentioned here is, that due to the physical
-limitations of the storage and another possible failure, two extra "states"
-were added specifically to signal a failure in the boot process.
-
-1. One of them is a result of any device read/write error, called panic and
-   will result in the bootloader hanging without booting the image in slot 0.
-
-2. Another state was added specifically to handle the situation in which a swap
-   was requested and the image in slot 1 fails to validate, due to hashing
-   or signing error. This state behaves as state IV with the extra action of
-   marking the image in slot 0 as confirmed.
+Note: An important caveat to the above is the result when a swap is requested
+      and the image in slot 1 fails to validate, due to a hashing or signing
+      error. This state behaves as State IV with the extra action of marking
+      the image in slot 0 as "OK", to prevent further attempts to swap.
 
 
 *** HIGH-LEVEL OPERATION

--- a/doc/design.txt
+++ b/doc/design.txt
@@ -217,10 +217,12 @@ can be in:
 *** IMAGE TRAILER
 
 For the bootloader to be able to determine the current state and what actions
-should be taken during the current boot operation, it uses metadata existing
-on both slots, and while doing a swap operation it can be located in scratch.
-This metadata is located at the end of the slot and is called image trailer.
-An image trailer has the following structure:
+should be taken during the current boot operation, it uses metadata stored in
+the image flash areas. While swapping, some of this metadata is temporarily
+copied into and out of the scratch area.
+
+This metadata is located at the end of the image flash areas, and is called an
+image trailer. An image trailer has the following structure:
 
      0                   1                   2                   3
      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -236,8 +238,8 @@ An image trailer has the following structure:
     |                       MAGIC (16 octets)                       |
     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
-These records are at the end of each image slot.  The offset immediately
-following such a record represents the start of the next flash area.
+The offset immediately following such a record represents the start of the next
+flash area.
 
 Note: "min-write-size" is a property of the flash hardware.  If the hardware
 allows individual bytes to be written at arbitrary addresses, then

--- a/doc/design.txt
+++ b/doc/design.txt
@@ -246,13 +246,23 @@ allows individual bytes to be written at arbitrary addresses, then
 min-write-size is 1.  If the hardware only allows writes at even addresses,
 then min-write-size is 2, and so on.
 
-The fields are defined as follows:
+An image trailer contains the following fields:
 
-1. Swap status: A series of single-byte records.  Each record corresponds to a
-flash sector in an image slot.  A swap status byte indicate the location of
-the corresponding sector data.  During an image swap, image data is moved one
-sector at a time.  The swap status is necessary for resuming a swap operation
-if the device rebooted before a swap operation completed.
+1. Swap status: A series of records which records the progress of an image
+swap.  To swap entire images, data are swapped between the two image areas one
+or more sectors at a time, like this:
+
+    - sector data in slot 0 is copied into scratch, then erased
+    - sector data in slot 1 is copied into slot 0, then erased
+    - sector data in scratch is copied into slot 1
+
+As it swaps images, the bootloader updates the swap status field in a way that
+allows it to compute how far this swap operation has progressed for each
+sector.  The swap status field can thus used to resume a swap operation if the
+bootloader is halted while a swap operation is ongoing and later reset. The
+factor of 128 is the maximum number of sectors mcuboot supports for each image;
+its value is a bootloader design decision. The factor of min-write-sz is due to
+the behavior of flash hardware. The factor of 3 is explained below.
 
 2. Copy done: A single byte indicating whether the image in this slot is
 complete (0x01=done; 0xff=not done).

--- a/doc/design.txt
+++ b/doc/design.txt
@@ -79,12 +79,13 @@ struct image_tlv {
 /*
  * Image header flags.
  */
-#define IMAGE_F_PIC                   0x00000001 /* Not currently supported. */
-#define IMAGE_F_SHA256                0x00000002 /* Image contains hash TLV */
-#define IMAGE_F_PKCS15_RSA2048_SHA256 0x00000004 /* PKCS15 w/RSA and SHA */
-#define IMAGE_F_ECDSA224_SHA256       0x00000008 /* ECDSA256 over SHA256 */
-#define IMAGE_F_NON_BOOTABLE          0x00000010 /* Split image app. */
-#define IMAGE_F_ECDSA256_SHA256       0x00000020 /* ECDSA256 over SHA256 */
+#define IMAGE_F_PIC                      0x00000001 /* Not supported. */
+#define IMAGE_F_SHA256                   0x00000002 /* Hash TLV is present */
+#define IMAGE_F_PKCS15_RSA2048_SHA256    0x00000004 /* PKCS15 w/RSA and SHA */
+#define IMAGE_F_ECDSA224_SHA256          0x00000008 /* ECDSA224 over SHA256 */
+#define IMAGE_F_NON_BOOTABLE             0x00000010 /* Split image app. */
+#define IMAGE_F_ECDSA256_SHA256          0x00000020 /* ECDSA256 over SHA256 */
+#define IMAGE_F_PKCS1_PSS_RSA2048_SHA256 0x00000040 /* PKCS1 PSS */
 
 /*
  * Image trailer TLV types.

--- a/doc/design.txt
+++ b/doc/design.txt
@@ -126,10 +126,20 @@ A portion of the flash memory is partitioned into two image slots: a primary
 slot (0) and a secondary slot (1).  The boot loader will only run an image from
 the primary slot, so images must be built such that they can run from that
 fixed location in flash.  If the boot loader needs to run the image resident in
-the secondary slot, it must swap the two images in flash prior to booting.
+the secondary slot, it must copy its contents into the primary slot before doing
+so, either by swapping the two images or by overwriting the contents of the
+primary slot. The bootloader supports either swap- or overwrite-based image
+upgrades, but must be configured at build time to choose one of these two
+strategies.
 
 In addition to the two image slots, the boot loader requires a scratch area to
 allow for reliable image swapping.
+
+The overwrite upgrade strategy is substantially simpler to implement than the
+image swapping strategy, especially since the bootloader must work properly
+even when it is reset during the middle of an image swap. For this reason, the
+rest of the document describes its behavior when configured to swap images
+during an upgrade.
 
 *** BOOT STATES
 

--- a/doc/design.txt
+++ b/doc/design.txt
@@ -6,7 +6,7 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #  http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
@@ -38,7 +38,7 @@ Therefore, functionality is delegated to the bootutil library when possible.
 The boot loader currently only supports images with the following
 characteristics:
     * Built to run from flash.
-    * Build to run from a fixed location (i.e., not position-independent).
+    * Built to run from a fixed location (i.e., not position-independent).
 
 *** IMAGE FORMAT
 
@@ -73,7 +73,7 @@ struct image_header {
 struct image_tlv {
     uint8_t  it_type;   /* IMAGE_TLV_[...]. */
     uint8_t  _pad;
-    uint16_t it_len     /* Data length (not including TLV header). */
+    uint16_t it_len;    /* Data length (not including TLV header). */
 };
 
 /*
@@ -553,7 +553,7 @@ indicates where the swap status region is located.
     ----------+------------+------------'
     source: none                        |
     ------------------------------------'
-    
+
               | slot-0     | scratch    |
     ----------+------------+------------|
         magic | Good       | Any        |
@@ -561,7 +561,7 @@ indicates where the swap status region is located.
     ----------+------------+------------'
     source: slot 0                      |
     ------------------------------------'
-    
+
               | slot-0     | scratch    |
     ----------+------------+------------|
         magic | Any        | Good       |
@@ -569,7 +569,7 @@ indicates where the swap status region is located.
     ----------+------------+------------'
     source: scratch                     |
     ------------------------------------'
-    
+
               | slot-0     | scratch    |
     ----------+------------+------------|
         magic | Unset      | Any        |


### PR DESCRIPTION
This continues the work in MCUB-67. The substantial change is deleting the 'pending' / 'confirmed' state space in favor of one defined in terms of 'swap types'.