### PR TITLE
zephyr: s/BLUETOOTH/BT/

### DIFF
--- a/boot/zephyr/prj-p256.conf
+++ b/boot/zephyr/prj-p256.conf
@@ -18,6 +18,6 @@ CONFIG_FLASH=y
 CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
 ### Disable Bluetooth by default
-# CONFIG_BLUETOOTH is not set
+# CONFIG_BT is not set
 
 CONFIG_MULTITHREADING=n

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -15,6 +15,6 @@ CONFIG_FLASH=y
 CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
 ### Disable Bluetooth by default
-# CONFIG_BLUETOOTH is not set
+# CONFIG_BT is not set
 
 CONFIG_MULTITHREADING=n


### PR DESCRIPTION
Upstream has made a breaking namespace change. Keep up.
