### PR TITLE
zephyr: add nrf52_blenano2 target

### DIFF
--- a/boot/zephyr/targets/nrf52_blenano2.h
+++ b/boot/zephyr/targets/nrf52_blenano2.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Linaro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file
+ * @brief Bootloader device specific configuration.
+ */
+
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_NRF5_DEV_NAME
+#define FLASH_ALIGN			4
+/* Flash sector size is provided by SoC family include */


### PR DESCRIPTION
Adds a new zephyr target for the nrf52_blenano2. This is the BLE
Nano 2 board created by Red Bear which contains a NRF52832 MCU.

Signed-off-by: Tyler Baker <tyler.baker@linaro.org>