### PR TITLE
Add support for Hexiwear k64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ tags
 rusty-tags.*
 
 # mynewt
-repos/
-project.state
-bin/
-targets/
+/repos/
+/project.state
+/bin/
+/targets/

--- a/boot/zephyr/targets/hexiwear_k64.h
+++ b/boot/zephyr/targets/hexiwear_k64.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2017 Linaro
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @file
+ * @brief Bootloader device specific configuration.
+ */
+
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_MCUX_DEV_NAME
+#define FLASH_ALIGN			8
+#define FLASH_AREA_IMAGE_SECTOR_SIZE	0x01000


### PR DESCRIPTION
The target is nearly identical to the frdm_k64f as far as mcuboot is concerned.

There is another fix to anchor the mynewt ignored directories so that Zephyr target files aren't ignored.