### PR TITLE
Zephyr: fit inside the boot partition again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,7 @@ SOURCE_DIR = boot/zephyr
 # Needed for mbedtls config-boot.h file.
 CFLAGS += -I$(CURDIR)/boot/zephyr/include
 
+DTC_OVERLAY_FILE := $(CURDIR)/boot/zephyr/dts.overlay
+export DTC_OVERLAY_FILE
+
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/boot/zephyr/dts.overlay
+++ b/boot/zephyr/dts.overlay
@@ -1,0 +1,5 @@
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -14,7 +14,8 @@ CONFIG_HEAP_MEM_POOL_SIZE=16384
 CONFIG_FLASH=y
 CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
-### Disable Bluetooth by default
-# CONFIG_BT is not set
-
 CONFIG_MULTITHREADING=n
+
+### Zephyr keeps turning on major subsystems by default that we don't want.
+# CONFIG_BT is not set
+# CONFIG_I2C is not set


### PR DESCRIPTION
This pull request forces mcuboot to fit within the boot partition using a DTS overlay, and enables it to do so on at least one STM32 target where it currently doesn't fit.

I did a spot-check build of a couple of other boards with different SoCs (96b_nitrogen and frdm_k64f) to verify we're still in bounds there as well.

hexiwear_k64f doesn't support this, but the build is broken on that board right now already anyway due to lack of flash partitions, so that's fine.
