### PR TITLE
zephyr: nrf5x: add nRF51 and nRF52832 dev kits as targets

### DIFF
--- a/boot/zephyr/targets/nrf51_pca10028.h
+++ b/boot/zephyr/targets/nrf51_pca10028.h
@@ -1,0 +1,9 @@
+/*
+ *  Copyright (C) 2017, Linaro Ltd
+ *  Copyright (C) 2017, Nordic Semiconductor ASA
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_NRF5_DEV_NAME
+#define FLASH_ALIGN			4
+/* Flash sector size is provided by SoC include */

--- a/boot/zephyr/targets/nrf52_pca10040.h
+++ b/boot/zephyr/targets/nrf52_pca10040.h
@@ -1,0 +1,9 @@
+/*
+ *  Copyright (C) 2017, Linaro Ltd
+ *  Copyright (C) 2017, Nordic Semiconductor ASA
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_NRF5_DEV_NAME
+#define FLASH_ALIGN			4
+/* Flash sector size is provided by SoC include */


### PR DESCRIPTION
Add the 2 official Nordic Development Kit targets that are missing from
the list in mcuboot, but supported in Zephyr.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>