### PR TITLE
Fix warning on overwrite-only

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -779,6 +779,7 @@ done:
     return rc;
 }
 
+#ifndef MCUBOOT_OVERWRITE_ONLY
 static inline int
 boot_status_init_by_id(int flash_area_id, const struct boot_status *bs)
 {
@@ -807,6 +808,7 @@ boot_status_init_by_id(int flash_area_id, const struct boot_status *bs)
 
     return 0;
 }
+#endif
 
 #ifndef MCUBOOT_OVERWRITE_ONLY
 static int


### PR DESCRIPTION
This function is unused in overwrite-only mode.  Clang seems to catch
this, whereas gcc does not.  Add the proper ifdefs so that the
simulator tests all pass on MacOS.

Signed-off-by: David Brown <david.brown@linaro.org>