### PR TITLE
Log error message when slot fails validation

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -590,6 +590,7 @@ boot_validate_slot(int slot)
              * continue booting from slot 0.
              */
         }
+        BOOT_LOG_ERR("Image in slot %d is not valid!", slot);
         return -1;
     }
 


### PR DESCRIPTION
This is helpful when testing an image that is not signed or signed with an invalid key.

Signed-off-by: Fabio Utzig <utzig@apache.org>