### PR TITLE
Fix repository for v1.0.0

### DIFF
--- a/repository.yml
+++ b/repository.yml
@@ -21,6 +21,7 @@ repo.name: mcuboot
 repo.versions:
     "0.0.0": "master"
     "0.9.0": "v0.9.0"
+    "1.0.0": "v1.0.0"
 
     "0-dev": "0.0.0"        # master
-    "0-latest": "0.9.0"
+    "0-latest": "1.0.0"     # latest stable release


### PR DESCRIPTION
When using the release version of mcuboot for mynewt I realised (thanks to @utzig) that the release v1.0.0 wasn't up-to-date in repository.yml.

This PR adds it and makes it the latest.