### PR TITLE
Use travis env variable to control check-signed-off-by

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: rust
 
 script:
   - set -e
-  - ./scripts/check-signed-off-by.sh
+  - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then ./scripts/check-signed-off-by.sh; fi
   - cd sim
   - cargo test
   - cargo test --features sig-rsa

--- a/scripts/check-signed-off-by.sh
+++ b/scripts/check-signed-off-by.sh
@@ -14,10 +14,6 @@
 
 # this retrieves the merge commit created by GH
 parents=(`git log -n 1 --format=%p HEAD`)
-branch=(`git rev-parse --abbrev-ref HEAD`)
-
-# Should only run in PR branches
-[[ ${branch} == "master" ]] && exit 0
 
 if [[ "${#parents[@]}" -ne 2 ]]; then
   echo "This PR's merge commit is missing a parent!"


### PR DESCRIPTION
Instead of trying to determine current branch using git, just rely on travis to know if this is a PR and if it is not, don't do signed-off-by checking.

Signed-off-by: Fabio Utzig <utzig@apache.org>