### PR TITLE
zephyr: samples: Fix possible unbootable without bootloader

### DIFF
--- a/samples/zephyr/hello-world/dts.overlay
+++ b/samples/zephyr/hello-world/dts.overlay
@@ -5,6 +5,8 @@
 
 / {
 	chosen {
+#if defined(CONFIG_IMG_MANAGER)
 		zephyr,code-partition = &slot0_partition;
+#endif
 	};
 };


### PR DESCRIPTION
It may cause the text section linked into wrong place when the
application do not support bootloader.

Signed-off-by: Ding Tao <miyatsu@qq.com>