### PR TITLE
assemble.py: Add explicit license declaration

### DIFF
--- a/scripts/assemble.py
+++ b/scripts/assemble.py
@@ -1,4 +1,18 @@
 #! /usr/bin/env python3
+#
+# Copyright 2017 Linaro Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Assemble multiple images into a single image that can be flashed on the device.


### PR DESCRIPTION
Although this file is likely implicitly licensed under the Apache 2.0
license because of the LICENSE file for this project, make this explicit
in this file.

Signed-off-by: David Brown <david.brown@linaro.org>