### PR TITLE
kconfig: Make MCUBOOT_VALIDATE_SLOT0 configurable through Kconfig

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -37,7 +37,15 @@
 #define BOOT_LOG_LEVEL BOOT_LOG_LEVEL_INFO
 #include "bootutil/bootutil_log.h"
 
-#ifdef MCUBOOT_MYNEWT
+#if defined(USE_MCUBOOT_CONFIG)
+#include <mcuboot_config.h>
+#endif
+
+// For legacy-reasons MYNEWT uses the define 'MCUBOOT_MYNEWT' and the
+// header 'mcuboot_config/mcuboot_config.h' to specify it's
+// mcuboot_config.h file. Eventually it will use the OS-agnostic
+// 'USE_MCUBOOT_CONFIG' define and 'mcuboot_config.h' header.
+#if defined(MCUBOOT_MYNEWT)
 #include "mcuboot_config/mcuboot_config.h"
 #endif
 

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -26,22 +26,6 @@ if (NOT DEFINED CONF_SIGNATURE_TYPE)
   set(CONF_SIGNATURE_TYPE RSA)
 endif()
 
-# If CONF_VALIDATE_SLOT0 is set, the bootloader attempts to validate
-# the signature of slot0 every boot.  This adds the signature check
-# time to every boot, but can mitigate against some changes that are
-# able to modify the flash image itself.
-#
-# To enable validation (this is the default):
-#
-#     cmake -DCONF_VALIDATE_SLOT0=YES [...]
-#
-# To disable validation:
-#
-#     cmake -DCONF_VALIDATE_SLOT0=NO [...]
-if (NOT DEFINED CONF_VALIDATE_SLOT0)
-  set(CONF_VALIDATE_SLOT0 YES)
-endif()
-
 # If CONF_UPGRADE_ONLY is set, overwrite slot0 with the upgrade image
 # instead of swapping them.  This prevents the fallback recovery, but
 # uses a much simpler code path.
@@ -87,11 +71,6 @@ macro(set_conf_file)
     set(CONF_FILE "${MCUBOOT_CONF_FILE}")
   endif()
 endmacro()
-
-# Check if we need to validate slot 0.
-if(CONF_VALIDATE_SLOT0 STREQUAL YES)
-  list(APPEND MCUBOOT_EXTRA_CFLAGS "-DMCUBOOT_VALIDATE_SLOT0")
-endif()
 
 # Enabling this option uses newer flash map APIs. This saves RAM and
 # avoids deprecated API usage.

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -26,6 +26,16 @@ config MCUBOOT_DEVICE_CPU_CORTEX_M0
 	default n
 	select SW_VECTOR_RELAY if !CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 
+config MCUBOOT_VALIDATE_SLOT0
+	bool
+	prompt "Validate slot 0"
+	default y
+	help
+	  If VALIDATE_SLOT0 is set, the bootloader attempts to validate
+	  the signature of slot0 every boot.  This adds the signature
+	  check time to every boot, but can mitigate against some changes
+	  that are able to modify the flash image itself.
+
 menuconfig MCUBOOT_SERIAL
 	bool
 	prompt "MCUBOOT serial recovery"

--- a/boot/zephyr/include/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config.h
@@ -1,0 +1,22 @@
+#ifndef H_MCUBOOT_CONFIG_
+#define H_MCUBOOT_CONFIG_
+
+// This header file acts as an adapter layer from Kconfig-style
+//
+//   '#define CONFIG_foo'
+//
+// to MCUBoot-style
+//
+//   '#define foo'
+//
+// macros. This file is manually maintained for now.
+//
+// The adapter layer keeps MCUBoot semi-agnostic to Zephyr and
+// MyNewt's configuration systems. See MyNewt's adapter in it's own
+// mcuboot_config.h file.
+
+#ifdef CONFIG_MCUBOOT_VALIDATE_SLOT0
+#define MCUBOOT_VALIDATE_SLOT0
+#endif
+
+#endif /* H_MCUBOOT_CONFIG_ */


### PR DESCRIPTION
RFC for approach to resolve https://github.com/runtimeco/mcuboot/issues/186