### PR TITLE
zephyr: fix MCUBOOT_TARGET_CONFIG definition

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -146,7 +146,7 @@ endif()
 target_include_directories(app PRIVATE include)
 target_include_directories(app PRIVATE targets)
 if(EXISTS "${APPLICATION_SOURCE_DIR}/targets/${BOARD}.h")
-  target_compile_definitions(app PRIVATE "-DMCUBOOT_TARGET_CONFIG='\"${BOARD}.h\"'")
+  target_compile_definitions(app PRIVATE "-DMCUBOOT_TARGET_CONFIG=\"${BOARD}.h\"")
 endif()
 
 # Zephyr port-specific sources.


### PR DESCRIPTION
When the target doesn't have good enough generic support for MCUBoot,
you can specify the flash layout etc on a per-board basis by creating
a header, boot/zephyr/targets/BOARD.h.

The build system tries to pick this up, but isn't doing it
correctly. Fix it.
