### PR TITLE
zephyr: boot: Use abs. path instead of rel. path for dts overlay

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -118,7 +118,7 @@ endif()
 
 # This is necessary to ensure mcuboot is linked into, and fits inside,
 # the boot partition.
-set(DTC_OVERLAY_FILE dts.overlay)
+set(DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dts.overlay)
 
 # Standard Zephyr application boilerplate:
 # http://docs.zephyrproject.org/application/application.html


### PR DESCRIPTION
When a relative path was used the build would fail when CMake was
invoked with the -B -H flags. Using an absolute path for the
dts.overlay flags fixes #187.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>