### PR TITLE
doc: Fix MCUboot capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This is mcuboot, version 1.1.0
 
-MCUBoot is a secure bootloader for 32-bit MCUs.   The goal of MCUBoot is to
+MCUboot is a secure bootloader for 32-bit MCUs.   The goal of MCUboot is to
 define a common infrastructure for the bootloader, system flash layout on
 microcontroller systems, and to provide a secure bootloader that enables
 easy software upgrade.

--- a/boot/zephyr/targets/arduino_101.h
+++ b/boot/zephyr/targets/arduino_101.h
@@ -21,10 +21,10 @@
 
 /*
  * NOTE: This flash layout is a simple one for demonstration purposes.
- * It assumes we are building MCUBoot as a 3rd-stage loader, leaving the
+ * It assumes we are building MCUboot as a 3rd-stage loader, leaving the
  * stock bootloaders on the Arduino 101 untouched.
  *
- * In this configuration MCUBoot will live at 0x40010000
+ * In this configuration MCUboot will live at 0x40010000
  */
 
 #define FLASH_DRIVER_NAME		CONFIG_SOC_FLASH_QMSI_DEV_NAME

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -5,7 +5,7 @@
 
 ## Version 1.1.0
 
-The 1.1.0 release of MCUBoot brings a lot of fixes/updates to its
+The 1.1.0 release of MCUboot brings a lot of fixes/updates to its
 inner workings, specially to its testing infrastructure which now
 enables a more thorough quality assurance of many of the available
 options. As expected of the 1.x.x release cycle, no breaking changes
@@ -32,7 +32,7 @@ None
 
 ## Version 1.0.0
 
-The 1.0.0 release of MCUBoot introduces a format change.  It is
+The 1.0.0 release of MCUboot introduces a format change.  It is
 important to either use the `imgtool.py` also from this release, or
 pass the `-2` to recent versions of the `newt` tool in order to
 generate image headers with the new format.  There should be no
@@ -76,7 +76,7 @@ None
 
 ## Version 0.9.0
 
-This is the first release of MCUBoot, a secure bootloader for 32-bit MCUs.
+This is the first release of MCUboot, a secure bootloader for 32-bit MCUs.
 It is designed to be operating system-agnostic and works over any transport -
 wired or wireless. It is also hardware independent, and relies  on hardware
 porting layers from the operating system it works with. For the first release,


### PR DESCRIPTION
The correct spelling is "MCUboot", so replace the instances that differ
from this.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>