### PR TITLE
zephyr: fix the build

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -6,8 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-
-set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../Kconfig)
+set(KCONFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/Kconfig)
 
 ########################
 # Configuration choices.


### PR DESCRIPTION
Since the Kconfig file was moved in 51a09210063 ("zephyr: Move Kconfig
file to boot/zephyr"), the CMakeLists.txt reference to it needs updating.
