### PR TITLE
zephyr: add compatibility shim for flash driver name

### DIFF
--- a/boot/zephyr/include/target.h
+++ b/boot/zephyr/include/target.h
@@ -31,6 +31,16 @@
 #endif /* !defined(MCUBOOT_TARGET_CONFIG) */
 
 /*
+ * Upstream Zephyr changed the name from FLASH_DRIVER_NAME to
+ * FLASH_DEV_NAME.  For now, let's just convert the Zephyr name to the
+ * one expected by MCUboot. This can be cleaned up after the upstream
+ * Zephyr tree has been released and settled down.
+ */
+#if !defined(FLASH_DRIVER_NAME) && defined(FLASH_DEV_NAME)
+#define FLASH_DRIVER_NAME FLASH_DEV_NAME
+#endif
+
+/*
  * Sanity check the target support.
  */
 #if !defined(FLASH_DRIVER_NAME) || \


### PR DESCRIPTION
The upstream Zephyr project is renaming FLASH_DRIVER_NAME to
FLASH_DEV_NAME as part of some changes related to device tree.

Work around this for now by keeping the MCUboot name the same if
FLASH_DRIVER_NAME is not provided by Zephyr, but FLASH_DEV_NAME is.
