### PR TITLE
zephyr: Fix type mismatch warning when link with new libc

### DIFF
--- a/boot/zephyr/flash_map.c
+++ b/boot/zephyr/flash_map.c
@@ -254,7 +254,7 @@ struct layout_data {
  * flash_area_get_sectors(). A lot of this can be inlined once
  * flash_area_to_sectors() is removed.
  */
-static int flash_area_layout(int idx, int *cnt, void *ret,
+static int flash_area_layout(int idx, uint32_t *cnt, void *ret,
                              flash_page_cb cb, struct layout_data *cb_data)
 {
     cb_data->area_idx = idx;
@@ -327,7 +327,7 @@ static bool to_sectors_cb(const struct flash_pages_info *info, void *datav)
     return true;
 }
 
-int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
+int flash_area_to_sectors(int idx, uint32_t *cnt, struct flash_area *ret)
 {
     struct layout_data data;
 

--- a/boot/zephyr/include/flash_map/flash_map.h
+++ b/boot/zephyr/include/flash_map/flash_map.h
@@ -136,7 +136,7 @@ int flash_area_get_sectors(int fa_id, uint32_t *count,
  * array of struct flash_area instead.
  */
 __attribute__((deprecated))
-int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret);
+int flash_area_to_sectors(int idx, uint32_t *cnt, struct flash_area *ret);
 
 int flash_area_id_from_image_slot(int slot);
 int flash_area_id_to_image_slot(int area_id);

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -138,7 +138,7 @@ void main(void)
     }
 
     BOOT_LOG_INF("Bootloader chainload address offset: 0x%x",
-                 rsp.br_image_off);
+                 (u32_t)rsp.br_image_off);
     zephyr_flash_area_warn_on_open();
     BOOT_LOG_INF("Jumping to the first image slot");
     do_boot(&rsp);

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -195,7 +195,7 @@ int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len)
                            len);
 }
 
-int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
+int flash_area_to_sectors(int idx, uint32_t *cnt, struct flash_area *ret)
 {
     uint32_t i;
     struct area *slot;


### PR DESCRIPTION
Fix this by add explicit cast.

Signed-off-by: Ding Tao <miyatsu@qq.com>