### PR TITLE
Change all doc links to use relative names

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -682,5 +682,4 @@ image was signed with a private key that corresponds to the embedded keyhash
 TLV.
 
 For information on embedding public keys in the boot loader, as well as
-producing signed images, see: [signed_images]({% link signed_images.md
-%}).
+producing signed images, see: [signed_images](signed_images.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,23 +16,22 @@ target with a complete port planned.
 ## Contents
 
 - General: this document
-- [Release notes]({% link release-notes.md %})
-- [design]({% link design.md %}): for the design
-- [imgtool]({% link imgtool.md %}): The image signing and key management
+- [Release notes](release-notes.md)
+- [design](design.md): for the design
+- [imgtool](imgtool.md): The image signing and key management
 - Usage instructions:
-  - [Zephyr]({% link readme-zephyr.md %})
-  - [Mynewt]({% link readme-mynewt.md %})
-  - [RIOT]({% link readme-riot.md %})
-- [Patch submission]({% link SubmittingPatches.md %}) for information
+  - [Zephyr](readme-zephyr.md)
+  - [Mynewt](readme-mynewt.md)
+  - [RIOT](readme-riot.md)
+- [Patch submission](SubmittingPatches.md) for information
   on how to contribute to mcuboot.
 - Testing
-  - The [Zephyr]({% link testplan-zephyr.md %}) test plan.
-  - The [mynewt]({% link testplan-mynewt.md %}) test plan.
-- Our [release process]({% link release.md %}).
+  - The [Zephyr](testplan-zephyr.md) test plan.
+  - The [mynewt](testplan-mynewt.md) test plan.
+- Our [release process](release.md).
 
-There is also a document about [signed images]({% link
-signed_images.md %}) that is out of date.  You should use `imgtool.py`
-instead of these documents.
+There is also a document about [signed images](signed_images.md) that is out
+of date.  You should use `imgtool.py` instead of these documents.
 
 ## Roadmap
 

--- a/docs/readme-zephyr.md
+++ b/docs/readme-zephyr.md
@@ -5,9 +5,9 @@ acquired the ability to be used as a bootloader for Zephyr as well.
 There are some pretty significant differences in how apps are built
 for Zephyr, and these are documented here.
 
-Please see the [design document]({% link design.md %}) for documentation on the
-design and operation of the bootloader itself.  This functionality
-should be the same on all supported RTOSs.
+Please see the [design document](design.md) for documentation on the design
+and operation of the bootloader itself. This functionality should be the same
+on all supported RTOSs.
 
 The first step required for Zephyr is making sure your board has flash
 partitions defined in its device tree. These partitions are:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -63,8 +63,8 @@ incompatible format changes throughout the 1.x.y release series.
   - Nordic nRF51 and nRF52832 dev kits
   - Hexiwear K64
 - Clearer sample applications have been added under `samples`.
-- Test plans for [zephyr](%{ link testplan-zephyr.md %}), and
-  [mynewt]({% link testplan-mynewt.md %}).
+- Test plans for [zephyr](testplan-zephyr.md), and
+  [mynewt](testplan-mynewt.md).
 - The simulator is now able to test RSA signatures.
 - There is an unimplemented `load_addr` header for future support for
   RAM loading in the bootloader.


### PR DESCRIPTION
Github pages assumes that links to files using relative names point to the same location so this should work both when accessing through the github browser and mcuboot.com

Signed-off-by: Fabio Utzig <utzig@apache.org>