### PR TITLE
bootutil: loader: fix BOOT_STATUS_ASSERT macro

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -47,7 +47,7 @@ static struct boot_loader_state boot_data;
 static int boot_status_fails = 0;
 #define BOOT_STATUS_ASSERT(x)                \
     do {                                     \
-        if (x) {                             \
+        if (!(x)) {                          \
             boot_status_fails++;             \
         }                                    \
     } while (0)


### PR DESCRIPTION
BOOT_STATUS_ASSERT increments the variable if the macro argument
is evaluated as true, which is incorrect behavior compared to the
ASSERT macro.