### PR TITLE
zephyr: Configure mbed TLS for PSS instead of V1.5

### DIFF
--- a/boot/zephyr/include/config-boot.h
+++ b/boot/zephyr/include/config-boot.h
@@ -68,7 +68,7 @@
 
 #ifdef MCUBOOT_SIGN_RSA
 #define MBEDTLS_RSA_C
-#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_PKCS1_V21
 #endif
 
 /* mbed TLS modules */


### PR DESCRIPTION
Although MCUboot has used PKCS#1 v2.1 (PSS) for some time now, the mbed
TLS config file was calling out v1.5.  This compiled because MCUboot
implements its own specialized version of the signature check, and only
needs the underlying primitives from mbed TLS.  (The general code in
mbed TLS is quite a bit larger).

To make it clear that we are always using PSS, change the mbed TLS
configuration to call this out explicitly.

Signed-off-by: David Brown <david.brown@linaro.org>