### PR TITLE
Mynewt app: Remove .OVERWITE suffix from pkg.deps

### DIFF
--- a/boot/mynewt/pkg.yml
+++ b/boot/mynewt/pkg.yml
@@ -34,5 +34,5 @@ pkg.deps:
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/sys/console/minimal"
 
-pkg.deps.BOOT_SERIAL.OVERWRITE:
+pkg.deps.BOOT_SERIAL:
     - "@mcuboot/boot/boot_serial"


### PR DESCRIPTION
The boot loader app needs all the base dependencies, whether or not
`BOOT_SERIAL` is enabled.  Therefore, it makes sense for the serial boot
loader to add to, rather than replace, the dependency list.

This bug in the pkg.yml file went unnoticed ealier because of an issue
in newt: it used to effectively ignore the `.OVERWRITE` suffix when it
was applied to `pkg.deps`.

NOTE: this change was made to the Mynewt boot loader in this PR: https://github.com/apache/mynewt-core/pull/784