### PR TITLE
zephyr: arm: Use proper macro to set MSP

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -19,7 +19,6 @@
 #include <gpio.h>
 #include <misc/__assert.h>
 #include <flash.h>
-#include <asm_inline.h>
 #include <drivers/system_timer.h>
 
 #include "target.h"
@@ -65,7 +64,7 @@ static void do_boot(struct boot_rsp *rsp)
                                      rsp->br_hdr->ih_hdr_size);
     irq_lock();
     sys_clock_disable();
-    _MspSet(vt->msp);
+    __set_MSP(vt->msp);
     ((void (*)(void))vt->reset)();
 }
 #else


### PR DESCRIPTION
The macro _MspSet has gone away in Zephyr.  Change to use the __set_MSP
macro from the CMSIS code that has always been present.  This allows
mcuboot to build with Zephyr after:

    commit c028f88b37d2a033d6a85c8d365ef048e1e4d621
    Author: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>
    Date:   Mon Mar 12 10:45:02 2018 +0100

        arch: arm: remove redundant asm inline headers

Fixes #246.

Signed-off-by: David Brown <david.brown@linaro.org>