### PR TITLE
boot_serial: Fix missing reponse to image erase command

### DIFF
--- a/boot/boot_serial/src/boot_serial_priv.h
+++ b/boot/boot_serial/src/boot_serial_priv.h
@@ -63,6 +63,7 @@ struct nmgr_hdr {
  */
 #define IMGMGR_NMGR_OP_STATE            0
 #define IMGMGR_NMGR_OP_UPLOAD           1
+#define IMGMGR_NMGR_ID_ERASE            5
 
 
 void boot_serial_input(char *buf, int len);


### PR DESCRIPTION
MCUmgr prior Image Upload command sends Image Erase command which
response is missing in boot_serial_input handler.
This results in inability to upload the image due to command timeout.
This patch fixes this issue by adding empty response to Image Erase
command.

This solution is loosely based on
commit 6c819b1304a8e360ea256e40860275c5a9184bde
Author: Marko Kiiskila <marko@runtime.io>
Date:   Mon Aug 28 16:41:42 2017 -0700

    boot_serial; access uart driver directly instead of going through console.

from apache-mynewt-core.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>