### PR TITLE
boot: zephyr: main: fix problem with missing asm_inline.h in zephyr builds.

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -19,7 +19,6 @@
 #include <gpio.h>
 #include <misc/__assert.h>
 #include <flash.h>
-#include <asm_inline.h>
 #include <drivers/system_timer.h>
 
 #include "target.h"
@@ -65,7 +64,7 @@ static void do_boot(struct boot_rsp *rsp)
                                      rsp->br_hdr->ih_hdr_size);
     irq_lock();
     sys_clock_disable();
-    _MspSet(vt->msp);
+    __set_MSP(vt->msp);
     ((void (*)(void))vt->reset)();
 }
 #else


### PR DESCRIPTION
This patch fix problem with missing asm_inline.h in zephyr builds.
asm_inline.h for ARM architecture was deleted, and _MspSet() is
unavailable in zephyr code-base.
This patch replace it by using __set_MSP().

Problem was introduced to zephyr by https://github.com/zephyrproject-rtos/zephyr/commit/c028f88b37d2a033d6a85c8d365ef048e1e4d621

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>