### PR TITLE
imgtool: Add 'create' alias for 'sign'

### DIFF
--- a/scripts/imgtool.py
+++ b/scripts/imgtool.py
@@ -122,8 +122,11 @@ def args():
     getpub.add_argument('-k', '--key', metavar='filename', required=True)
     getpub.add_argument('-l', '--lang', metavar='lang', default='c')
 
-    sign = subs.add_parser('sign', help='Sign an image with a private key')
-    sign.add_argument('-k', '--key', metavar='filename')
+    sign = subs.add_parser('sign',
+            help='Sign an image with a private key (or create an unsigned image)',
+            aliases=['create'])
+    sign.add_argument('-k', '--key', metavar='filename',
+            help='private key to sign, or no key for an unsigned image')
     sign.add_argument("--align", type=alignment_value, required=True)
     sign.add_argument("-v", "--version", type=version.decode_version, required=True)
     sign.add_argument("-H", "--header-size", type=intparse, required=True)


### PR DESCRIPTION
The imgtool's `sign` command also works without a key, but it doesn't
sign, only appends a hash.  Add a `create` alias to this command so that
this usage makes more sense.

Fixes #240

Signed-off-by: David Brown <david.brown@linaro.org>