### PR TITLE
Restore functionality on nRF devices

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -17,6 +17,7 @@ config MCUBOOT_DEVICE_SETTINGS
 	default y
         # CPU options
 	select MCUBOOT_DEVICE_CPU_CORTEX_M0 if CPU_CORTEX_M0
+	select MCUBOOT_DEVICE_NRF if SOC_FAMILY_NRF
         # Enable flash page layout if available
 	select FLASH_PAGE_LAYOUT if FLASH_HAS_PAGE_LAYOUT
 
@@ -25,6 +26,12 @@ config MCUBOOT_DEVICE_CPU_CORTEX_M0
 	bool
 	default n
 	select SW_VECTOR_RELAY if !CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
+
+config MCUBOOT_DEVICE_NRF
+	# Hidden selector for Nordic nRF settings
+	bool
+	default n
+	select SOC_FLASH_NRF5
 
 menuconfig MCUBOOT_SERIAL
 	bool

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -118,7 +118,7 @@ void main(void)
                             GPIO_DIR_IN | GPIO_PUD_PULL_UP);
     __ASSERT(rc, "Error of boot detect pin initialization.\n");
 
-    rc = gpio_pin_read(detect_port, CONFIG_BOOT_SERIAL_DETECT_PIN, 
+    rc = gpio_pin_read(detect_port, CONFIG_BOOT_SERIAL_DETECT_PIN,
                        &detect_value);
     __ASSERT(rc, "Error of the reading the detect pin.\n");
 


### PR DESCRIPTION
Testing with the latest Zephyr is showing that CONFIG_SOC_FLASH_NRF5 is no longer set. This manifests in the following error message:

[MCUBOOT] [INF] main: Starting bootloader
[MCUBOOT] [ERR] main: Flash device not found

Instead of relying on Zephyr to enable individual SOC flash drivers based on the global CONFIG_FLASH value, just explicitly select CONFIG_SOC_FLASH_NRF5 in a new device-specific MCUBOOT_DEVICE_NRF hidden config. This fixes the problem.