### PR TITLE
zephyr: CMakeLists: allow users to specify DTC_OVERLAY_FILE fragments

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -133,9 +133,16 @@ if (NOT DEFINED BOARD)
   set(BOARD qemu_x86)
 endif()
 
-# This is necessary to ensure mcuboot is linked into, and fits inside,
-# the boot partition.
-set(DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dts.overlay)
+# Add a common dts overlay necessary to ensure mcuboot is linked into,
+# and fits inside, the boot partition. (If the user specified a
+# DTC_OVERLAY_FILE on the CMake command line, we need to append onto
+# the list).
+if(DTC_OVERLAY_FILE)
+  set(DTC_OVERLAY_FILE
+      "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/dts.overlay")
+else()
+  set(DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dts.overlay)
+endif()
 
 # Enable Zephyr runner options which request mass erase if so
 # configured.


### PR DESCRIPTION
Allow the user to add additional device tree overlays onto the default one that sets up the code partition.