### PR TITLE
Fix boot_serial size of allocated buffers

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -41,11 +41,11 @@
 #include "bootutil/image.h"
 #include "bootutil/bootutil.h"
 
-#define BOOT_AREA_DESC_MAX  (256)
-#define AREA_DESC_MAX       (BOOT_AREA_DESC_MAX)
+#define BOOT_AREA_DESC_MAX    (256)
+#define AREA_DESC_MAX         (BOOT_AREA_DESC_MAX)
 
 #ifdef MCUBOOT_SERIAL
-#define BOOT_SER_CONS_INPUT         128
+#define BOOT_SER_CONS_INPUT   256
 #endif
 
 /*

--- a/docs/readme-mynewt.md
+++ b/docs/readme-mynewt.md
@@ -36,3 +36,17 @@ different TLV structure, so images created by `newt` have to be generated
 in this new format. That is done by passing the extra parameter `-2` as in:
 
 `newt create-image <target> <version> <pubkey> -2`
+
+# Boot serial functionality with Mynewt
+
+Building with `BOOT_SERIAL: 1` enables some basic management functionality
+like listing images and uploading a new image to `slot0`. The serial bootloader
+requires that `mtu` is set to a value that is less than or equal to `256`.
+This can be done either by editing `~/.newtmgr.cp.json` and setting the `mtu`
+for the connection profile, or specifying you connection string manually as in:
+
+```
+newtmgr --conntype serial --connstring "dev=/dev/ttyUSB0,mtu=256" image upload -e blinky.img
+```
+
+where `/dev/ttyUSB0` is your serial port.


### PR DESCRIPTION
This fixes an issue where while doing an image upload `newtmgr`/`mcumgr` would send packets that were impossible do base64decode in a 128 byte buffer.

Signed-off-by: Fabio Utzig <utzig@apache.org>