### PR TITLE
fix warnings while building along with serial recovery

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -118,7 +118,7 @@ bs_find_val(char *buf, char *name)
     ptr += strlen(name);
 
     while (*ptr != '\0') {
-        if (*ptr != ':' && !isspace(*ptr)) {
+        if (*ptr != ':' && !isspace((int)*ptr)) {
             break;
         }
         ++ptr;
@@ -292,7 +292,7 @@ bs_echo_ctl(char *buf, int len)
  * Reset, and (presumably) boot to newly uploaded image. Flush console
  * before restarting.
  */
-static int
+static void
 bs_reset(char *buf, int len)
 {
     cbor_encoder_create_map(&bs_root, &bs_rsp, CborIndefiniteLength);

--- a/boot/zephyr/os.c
+++ b/boot/zephyr/os.c
@@ -23,7 +23,6 @@
 #include "os/os_heap.h"
 
 #ifdef MCUBOOT_USE_MBED_TLS
-#define MBEDTLS_CONFIG_FILE CONFIG_MBEDTLS_CFG_FILE
 
 #include <mbedtls/platform.h>
 #include <mbedtls/memory_buffer_alloc.h>
@@ -45,7 +44,6 @@ void os_heap_init(void)
     mbedtls_memory_buffer_alloc_init(mempool, sizeof(mempool));
 }
 #else
-#define MBEDTLS_CONFIG_FILE MCUBOOT_MBEDTLS_CFG_FILE
 void os_heap_init(void)
 {
 }


### PR DESCRIPTION
Following warnings were fixed within this patch:

 'isspace' macro should take an int value

 function 'bs_reset' should return void

 redefinition of 'MBEDTLS_CONFIG_FILE' macro while
 it is already defined by the zephyr build system.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>