### PR TITLE
Update nokogiri due to CVE-2017-1825

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
     minitest (5.10.3)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.2.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2017-18258

Signed-off-by: Fabio Utzig <utzig@apache.org>