### PR TITLE
Mynewt unit tests - Add repo prefix to dependency lists

### DIFF
--- a/boot/boot_serial/test/pkg.yml
+++ b/boot/boot_serial/test/pkg.yml
@@ -24,7 +24,7 @@ pkg.keywords:
 
 pkg.deps:
     - "@mcuboot/boot/boot_serial"
-    - test/testutil
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"

--- a/boot/bootutil/test/pkg.yml
+++ b/boot/bootutil/test/pkg.yml
@@ -23,8 +23,8 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps: 
-    - boot/bootutil
-    - test/testutil
+    - "@mcuboot/boot/bootutil"
+    - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:
-    - sys/console/stub
+    - "@apache-mynewt-core/sys/console/stub"


### PR DESCRIPTION
This PR addresses the following newt errors:
```
[ccollins@ccollins-mac:~/tmp/myproj3]$ newt test @mcuboot/boot/bootutil @mcuboot/boot/boot_serial
Testing package @mcuboot/boot/bootutil/test
Could not resolve package dependency: @mcuboot/test/testutil; depender: boot/bootutil/testTesting package @mcuboot/boot/boot_serial/test
Could not resolve package dependency: @mcuboot/test/testutil; depender: boot/boot_serial/test
Error: Test failure(s):
Passed tests: []
Failed tests: [boot/bootutil/test boot/boot_serial/test]
```

The unit tests depend on a few Mynewt packages (`test/testutil` and `sys/console/stub`).  If there is no repo prefix in the dependency specifier, newt assumes the package is in the local repo (mcuboot)`.  This PR adds the `@apache-mynewt-core/` prefix to these dependencies.

Note: This PR only fixes the newt errors.  Some build errors get reported after this fix is applied.