### PR TITLE
Fix leftovers from image_header v1

### DIFF
--- a/boot/bootutil/include/bootutil/image.h
+++ b/boot/bootutil/include/bootutil/image.h
@@ -80,11 +80,11 @@ struct image_header {
     uint32_t ih_magic;
     uint32_t ih_load_addr;
     uint16_t ih_hdr_size; /* Size of image header (bytes). */
-    uint16_t _pad2;
+    uint16_t _pad1;
     uint32_t ih_img_size; /* Does not include header. */
     uint32_t ih_flags;    /* IMAGE_F_[...]. */
     struct image_version ih_ver;
-    uint32_t _pad3;
+    uint32_t _pad2;
 };
 
 /** Image TLV header.  All fields in little endian. */

--- a/scripts/imgtool.py
+++ b/scripts/imgtool.py
@@ -90,9 +90,11 @@ def do_sign(args):
     img.save(args.outfile)
 
 subcmds = {
-        'keygen': do_keygen,
-        'getpub': do_getpub,
-        'sign': do_sign, }
+    'keygen': do_keygen,
+    'getpub': do_getpub,
+    'sign': do_sign,
+    'create': do_sign,
+}
 
 def alignment_value(text):
     value = int(text)

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -42,7 +42,6 @@ TLV_VALUES = {
 
 TLV_INFO_SIZE = 4
 TLV_INFO_MAGIC = 0x6907
-TLV_HEADER_SIZE = 4
 
 # Sizes of the image trailer, depending on flash write size.
 trailer_sizes = {
@@ -145,41 +144,31 @@ class Image():
         approximate the size of the signature."""
 
         flags = 0
-        tlvsz = 0
-        if key is not None:
-            tlvsz += TLV_HEADER_SIZE + key.sig_len()
-
-        tlvsz += 4 + hashlib.sha256().digest_size
-        tlvsz += 4 + hashlib.sha256().digest_size
 
         fmt = ('<' +
             # type ImageHdr struct {
             'I' +   # Magic uint32
-            'H' +   # TlvSz uint16
-            'B' +   # KeyId uint8
-            'B' +   # Pad1  uint8
+            'I' +   # LoadAddr uint32
             'H' +   # HdrSz uint16
-            'H' +   # Pad2  uint16
+            'H' +   # Pad1  uint16
             'I' +   # ImgSz uint32
             'I' +   # Flags uint32
             'BBHI' + # Vers  ImageVersion
-            'I'     # Pad3  uint32
+            'I'     # Pad2  uint32
             ) # }
         assert struct.calcsize(fmt) == IMAGE_HEADER_SIZE
         header = struct.pack(fmt,
                 IMAGE_MAGIC,
-                tlvsz, # TlvSz
-                0, # KeyId (TODO: allow other ids)
-                0,  # Pad1
+                0, # LoadAddr
                 self.header_size,
-                0, # Pad2
+                0, # Pad1
                 len(self.payload) - self.header_size, # ImageSz
                 flags, # Flags
                 self.version.major,
                 self.version.minor or 0,
                 self.version.revision or 0,
                 self.version.build or 0,
-                0) # Pad3
+                0) # Pad2
         self.payload = bytearray(self.payload)
         self.payload[:len(header)] = header
 


### PR DESCRIPTION
This removes the old "TLV size" and "keyId" fields that used to exist in the old image header format and updates it to use `load_addr`. Also fixes the name of reserved fields to index from 1.

This fixes #279 

Signed-off-by: Fabio Utzig <utzig@apache.org>