### PR TITLE
sim: Add missing license headers

### DIFF
--- a/sim/mcuboot-sys/csupport/bootsim.h
+++ b/sim/mcuboot-sys/csupport/bootsim.h
@@ -1,3 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #ifndef H_BOOTSIM_
 #define H_BOOTSIM_
 

--- a/sim/mcuboot-sys/csupport/mcuboot_config/mcuboot_assert.h
+++ b/sim/mcuboot-sys/csupport/mcuboot_config/mcuboot_assert.h
@@ -1,3 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 #ifndef __MCUBOOT_ASSERT_H__
 #define __MCUBOOT_ASSERT_H__
 


### PR DESCRIPTION
These (currently) trivial files do not add license headers.  Go ahead
and add the boilerplate Apache header.

In addition, I've also added an SPDX header.  Although this is a first
for the MCUboot project, this will provide a template for adding these
headers to other files.

Fixes #282

Signed-off-by: David Brown <david.brown@linaro.org>
CC: Marti Bolivar <marti@opensourcefoundries.com>
CC: Fabio Utzig <utzig@apache.org>