### PR TITLE
boot_serial rework

### DIFF
--- a/boot/boot_serial/include/boot_serial/boot_serial.h
+++ b/boot/boot_serial/include/boot_serial/boot_serial.h
@@ -24,12 +24,24 @@
 extern "C" {
 #endif
 
-/*
- * Start processing newtmgr commands for uploading image0 over serial.
- *
- * Open console serial port and wait for download command.
+/**
+ * Function pointers to read/write data from uart.
+ * read returns the number of bytes read, str points to buffer to fill,
+ *  cnt is the number of bytes to fill within buffer, *newline will be
+ *  set if newline is the last character.
+ * write takes as it's arguments pointer to data to write, and the count
+ *  of bytes.
  */
-void boot_serial_start(int max_input);
+struct boot_uart_funcs {
+    int (*read)(char *str, int cnt, int *newline);
+    void (*write)(const char *ptr, int cnt);
+};
+
+/**
+ * Start processing newtmgr commands for uploading image0 over serial.
+ * Assumes serial port is open and waits for download command.
+ */
+void boot_serial_start(const struct boot_uart_funcs *f);
 
 #ifdef __cplusplus
 }

--- a/boot/boot_serial/pkg.yml
+++ b/boot/boot_serial/pkg.yml
@@ -32,8 +32,8 @@ pkg.deps:
     - "@apache-mynewt-core/encoding/cborattr"
     - "@apache-mynewt-core/encoding/base64"
     - "@mcuboot/boot/mynewt/flash_map_backend"
+    - "@mcuboot/boot/mynewt/boot_uart"
     - "@apache-mynewt-core/util/crc"
 
 pkg.req_apis:
-    - console
     - bootloader

--- a/boot/boot_serial/pkg.yml
+++ b/boot/boot_serial/pkg.yml
@@ -29,7 +29,6 @@ pkg.deps:
     - "@apache-mynewt-core/hw/hal"
     - "@apache-mynewt-core/kernel/os"
     - "@apache-mynewt-core/encoding/tinycbor"
-    - "@apache-mynewt-core/encoding/cborattr"
     - "@apache-mynewt-core/encoding/base64"
     - "@mcuboot/boot/mynewt/flash_map_backend"
     - "@mcuboot/boot/mynewt/boot_uart"

--- a/boot/boot_serial/src/CMakeLists.txt
+++ b/boot/boot_serial/src/CMakeLists.txt
@@ -2,7 +2,4 @@ zephyr_sources(boot_serial.c)
 
 zephyr_include_directories(${BOOT_DIR}/bootutil/include)
 
-zephyr_include_directories($ENV{ZEPHYR_BASE}/ext/lib/mgmt/mcumgr/cborattr/include)
-zephyr_sources($ENV{ZEPHYR_BASE}/ext/lib/mgmt/mcumgr/cborattr/src/cborattr.c)
-
 zephyr_link_libraries_ifdef(CONFIG_TINYCBOR TINYCBOR)

--- a/boot/boot_serial/src/boot_serial_priv.h
+++ b/boot/boot_serial/src/boot_serial_priv.h
@@ -41,8 +41,6 @@ extern "C" {
 #define NMGR_OP_READ            0
 #define NMGR_OP_WRITE           2
 
-#define NMGR_F_CBOR_RSP_COMPLETE 0x01
-
 #define MGMT_GROUP_ID_DEFAULT   0
 #define MGMT_GROUP_ID_IMAGE     1
 
@@ -61,9 +59,8 @@ struct nmgr_hdr {
 /*
  * From imgmgr.h
  */
-#define IMGMGR_NMGR_OP_STATE            0
-#define IMGMGR_NMGR_OP_UPLOAD           1
-
+#define IMGMGR_NMGR_ID_STATE            0
+#define IMGMGR_NMGR_ID_UPLOAD           1
 
 void boot_serial_input(char *buf, int len);
 

--- a/boot/boot_serial/syscfg.yml
+++ b/boot/boot_serial/syscfg.yml
@@ -24,7 +24,7 @@ syscfg.defs:
         restrictions:
             - '(BOOT_SERIAL_DETECT_PIN != -1) ||
                (BOOT_SERIAL_DETECT_TIMEOUT != 0) ||
-	       (BOOT_SERIAL_NVREG_INDEX != -1)'
+               (BOOT_SERIAL_NVREG_INDEX != -1)'
 
     BOOT_SERIAL_DETECT_PIN_CFG:
         description: >
@@ -50,7 +50,7 @@ syscfg.defs:
         restrictions:
             - '(BOOT_SERIAL_DETECT_PIN != -1) ||
                (BOOT_SERIAL_DETECT_TIMEOUT != 0) ||
-	       (BOOT_SERIAL_NVREG_INDEX != -1)'
+               (BOOT_SERIAL_NVREG_INDEX != -1)'
 
     BOOT_SERIAL_DETECT_STRING:
         description: >
@@ -89,4 +89,4 @@ syscfg.defs:
         restrictions:
             - '(BOOT_SERIAL_DETECT_PIN != -1) ||
                (BOOT_SERIAL_DETECT_TIMEOUT != 0) ||
-	       (BOOT_SERIAL_NVREG_INDEX != -1)'
+               (BOOT_SERIAL_NVREG_INDEX != -1)'

--- a/boot/boot_serial/syscfg.yml
+++ b/boot/boot_serial/syscfg.yml
@@ -20,9 +20,11 @@ syscfg.defs:
     BOOT_SERIAL_DETECT_PIN:
         description: >
             Start the serial boot loader if this pin is asserted at boot time.
-        value:
+        value: '-1'
         restrictions:
-            - '$notnull'
+            - '(BOOT_SERIAL_DETECT_PIN != -1) ||
+               (BOOT_SERIAL_DETECT_TIMEOUT != 0) ||
+	       (BOOT_SERIAL_NVREG_INDEX != -1)'
 
     BOOT_SERIAL_DETECT_PIN_CFG:
         description: >
@@ -35,6 +37,30 @@ syscfg.defs:
             to start.
         value: 0
 
+    BOOT_SERIAL_DETECT_TIMEOUT:
+        description: >
+            The duration, in milliseconds, to listen on the UART for the
+            management string (BOOT_SERIAL_DETECT_STRING).  If the management
+            string is detected during this period, the serial boot loader is
+            started.  If the period expires without the management string being
+            received, the boot loader runs in the normal (non-serial) mode.
+            Specify 0 to disable listening on the UART for the management
+            string.
+        value: 0
+        restrictions:
+            - '(BOOT_SERIAL_DETECT_PIN != -1) ||
+               (BOOT_SERIAL_DETECT_TIMEOUT != 0) ||
+	       (BOOT_SERIAL_NVREG_INDEX != -1)'
+
+    BOOT_SERIAL_DETECT_STRING:
+        description: >
+            The string to listen for on the UART.  If this management string is
+            detected during the timeout period, the serial boot loader is
+            started.  If the period expires without this string being received,
+            the boot loader runs in the normal (non-serial) mode.  This setting
+            has no effect if BOOT_SERIAL_DETECT_TIMEOUT is set to 0.
+        value: '"nmgr"'
+
     BOOT_SERIAL_REPORT_PIN:
         description: >
             The GPIO to toggle while the serial boot loader is running.  Set to
@@ -45,3 +71,22 @@ syscfg.defs:
         description: >
             The toggle rate, in Hz, of the serial boot loader report pin.
         value: 4
+
+    BOOT_SERIAL_NVREG_MAGIC:
+        description: >
+            Magic number, to be saved in a retained (reset-surviving) register.
+            If the value in the register matches, the serial bootloader will
+            load. Value must not be 0.
+        value: 0xB7
+        restrictions:
+            - '(BOOT_SERIAL_NVREG_MAGIC != 0)'
+
+    BOOT_SERIAL_NVREG_INDEX:
+        description: >
+            Index of retained register to use (using hal_nvreg_read) for reading
+            magic value.
+        value: -1
+        restrictions:
+            - '(BOOT_SERIAL_DETECT_PIN != -1) ||
+               (BOOT_SERIAL_DETECT_TIMEOUT != 0) ||
+	       (BOOT_SERIAL_NVREG_INDEX != -1)'

--- a/boot/boot_serial/test/pkg.yml
+++ b/boot/boot_serial/test/pkg.yml
@@ -24,6 +24,7 @@ pkg.keywords:
 
 pkg.deps:
     - "@mcuboot/boot/boot_serial"
+    - "@mcuboot/boot/bootutil"
     - "@apache-mynewt-core/test/testutil"
 
 pkg.deps.SELFTEST:

--- a/boot/boot_serial/test/src/boot_test.c
+++ b/boot/boot_serial/test/src/boot_test.c
@@ -65,8 +65,7 @@ boot_serial_test(void)
 int
 main(void)
 {
-    ts_config.ts_print_results = 1;
-    tu_init();
+    sysinit();
 
     boot_serial_test();
 

--- a/boot/boot_serial/test/src/testcases/boot_serial_empty_img_msg.c
+++ b/boot/boot_serial/test/src/testcases/boot_serial_empty_img_msg.c
@@ -27,7 +27,7 @@ TEST_CASE(boot_serial_empty_img_msg)
     memset(hdr, 0, sizeof(*hdr));
     hdr->nh_op = NMGR_OP_WRITE;
     hdr->nh_group = htons(MGMT_GROUP_ID_IMAGE);
-    hdr->nh_id = IMGMGR_NMGR_OP_UPLOAD;
+    hdr->nh_id = IMGMGR_NMGR_ID_UPLOAD;
     hdr->nh_len = htons(2);
     strcpy((char *)(hdr + 1), "{}");
 

--- a/boot/boot_serial/test/src/testcases/boot_serial_img_msg.c
+++ b/boot/boot_serial/test/src/testcases/boot_serial_img_msg.c
@@ -50,7 +50,7 @@ TEST_CASE(boot_serial_img_msg)
     memset(hdr, 0, sizeof(*hdr));
     hdr->nh_op = NMGR_OP_WRITE;
     hdr->nh_group = htons(MGMT_GROUP_ID_IMAGE);
-    hdr->nh_id = IMGMGR_NMGR_OP_UPLOAD;
+    hdr->nh_id = IMGMGR_NMGR_ID_UPLOAD;
 
     memcpy(hdr + 1, payload, sizeof payload);
     hdr->nh_len = htons(sizeof payload);

--- a/boot/boot_serial/test/src/testcases/boot_serial_upload_bigger_image.c
+++ b/boot/boot_serial/test/src/testcases/boot_serial_upload_bigger_image.c
@@ -83,7 +83,7 @@ TEST_CASE(boot_serial_upload_bigger_image)
         memset(hdr, 0, sizeof(*hdr));
         hdr->nh_op = NMGR_OP_WRITE;
         hdr->nh_group = htons(MGMT_GROUP_ID_IMAGE);
-        hdr->nh_id = IMGMGR_NMGR_OP_UPLOAD;
+        hdr->nh_id = IMGMGR_NMGR_ID_UPLOAD;
 
         if (off) {
             memcpy(buf + payload_off, payload_next, sizeof payload_next);

--- a/boot/boot_serial/test/syscfg.yml
+++ b/boot/boot_serial/test/syscfg.yml
@@ -19,3 +19,5 @@
 # Package: boot/boot_serial/test
 
 syscfg.vals:
+    # This is here to work around the $notnull syscfg restriction.
+    BOOT_SERIAL_DETECT_PIN: 0

--- a/boot/mynewt/boot_uart/include/boot_uart/boot_uart.h
+++ b/boot/mynewt/boot_uart/include/boot_uart/boot_uart.h
@@ -23,6 +23,6 @@
 int boot_uart_open(void);
 void boot_uart_close(void);
 int boot_uart_read(char *str, int cnt, int *newline);
-void boot_uart_write(char *ptr, int cnt);
+void boot_uart_write(const char *ptr, int cnt);
 
 #endif /* _BOOT_UART_H_ */

--- a/boot/mynewt/boot_uart/include/boot_uart/boot_uart.h
+++ b/boot/mynewt/boot_uart/include/boot_uart/boot_uart.h
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef _BOOT_UART_H_
+#define _BOOT_UART_H_
+
+int boot_uart_open(void);
+void boot_uart_close(void);
+int boot_uart_read(char *str, int cnt, int *newline);
+void boot_uart_write(char *ptr, int cnt);
+
+#endif /* _BOOT_UART_H_ */

--- a/boot/mynewt/boot_uart/pkg.yml
+++ b/boot/mynewt/boot_uart/pkg.yml
@@ -17,29 +17,16 @@
 # under the License.
 #
 
-pkg.name: boot/mynewt
-pkg.type: app
-pkg.description: "Mynewt port of mcuboot"
+pkg.name: boot/mynewt/boot_uart
+pkg.description: "For interfacing with uart from boot_serial"
 pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
 pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
     - loader
-
-pkg.cflags:
-    - "-DMCUBOOT_MYNEWT"
+    - boot
+    - bootloader
 
 pkg.deps:
-    - "@mcuboot/boot/mynewt/mcuboot_config"
-    - "@mcuboot/boot/bootutil"
-    - "@mcuboot/boot/mynewt/flash_map_backend"
-    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/hw/hal"
 
-pkg.deps.BOOTUTIL_NO_LOGGING:
-    - "@apache-mynewt-core/sys/console/stub"
 
-pkg.deps.BOOTUTIL_HAVE_LOGGING:
-    - "@apache-mynewt-core/sys/console/minimal"
-
-pkg.deps.BOOT_SERIAL:
-    - "@mcuboot/boot/boot_serial"
-    - "@mcuboot/boot/mynewt/boot_uart"

--- a/boot/mynewt/boot_uart/src/boot_uart.c
+++ b/boot/mynewt/boot_uart/src/boot_uart.c
@@ -150,14 +150,14 @@ bs_tx_char(void *arg)
  * sends, so we can drop the outgoing data here.
  */
 void
-boot_uart_write(char *ptr, int cnt)
+boot_uart_write(const char *ptr, int cnt)
 {
 }
 
 #else
 
 void
-boot_uart_write(char *ptr, int cnt)
+boot_uart_write(const char *ptr, int cnt)
 {
     int sr;
 

--- a/boot/mynewt/boot_uart/src/boot_uart.c
+++ b/boot/mynewt/boot_uart/src/boot_uart.c
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <assert.h>
+#include <stddef.h>
+#include <inttypes.h>
+#include "os/mynewt.h"
+#include <uart/uart.h>
+
+/*
+ * RX is a ring buffer, which gets drained constantly.
+ * TX blocks until buffer has been completely transmitted.
+ */
+#define CONSOLE_HEAD_INC(cr) (((cr)->head + 1) & (sizeof((cr)->buf) - 1))
+#define CONSOLE_TAIL_INC(cr) (((cr)->tail + 1) & (sizeof((cr)->buf) - 1))
+
+struct {
+    uint8_t head;
+    uint8_t tail;
+    uint8_t buf[16];
+} bs_uart_rx;
+
+struct {
+    uint8_t *ptr;
+    int cnt;
+} volatile bs_uart_tx;
+
+static struct uart_dev *bs_uart;
+
+static int bs_rx_char(void *arg, uint8_t byte);
+static int bs_tx_char(void *arg);
+
+int
+boot_uart_open(void)
+{
+    struct uart_conf uc = {
+        .uc_speed = MYNEWT_VAL(CONSOLE_UART_BAUD),
+        .uc_databits = 8,
+        .uc_stopbits = 1,
+        .uc_parity = UART_PARITY_NONE,
+        .uc_flow_ctl = MYNEWT_VAL(CONSOLE_UART_FLOW_CONTROL),
+        .uc_tx_char = bs_tx_char,
+        .uc_rx_char = bs_rx_char,
+    };
+
+    bs_uart = (struct uart_dev *)os_dev_open(MYNEWT_VAL(CONSOLE_UART_DEV),
+      OS_TIMEOUT_NEVER, &uc);
+    if (!bs_uart) {
+        return -1;
+    }
+    return 0;
+}
+
+void
+boot_uart_close(void)
+{
+    os_dev_close(&bs_uart->ud_dev);
+    bs_uart_rx.head = 0;
+    bs_uart_rx.tail = 0;
+    bs_uart_tx.cnt = 0;
+}
+
+static int
+bs_rx_char(void *arg, uint8_t byte)
+{
+    if (CONSOLE_HEAD_INC(&bs_uart_rx) == bs_uart_rx.tail) {
+        /*
+         * RX queue full. Reader must drain this.
+         */
+        return -1;
+    }
+    bs_uart_rx.buf[bs_uart_rx.head] = byte;
+    bs_uart_rx.head = CONSOLE_HEAD_INC(&bs_uart_rx);
+    return 0;
+}
+
+static uint8_t
+bs_pull_char(void)
+{
+    uint8_t ch;
+
+    ch = bs_uart_rx.buf[bs_uart_rx.tail];
+    bs_uart_rx.tail = CONSOLE_TAIL_INC(&bs_uart_rx);
+    return ch;
+}
+
+int
+boot_uart_read(char *str, int cnt, int *newline)
+{
+    int i;
+    int sr;
+    uint8_t ch;
+
+    *newline = 0;
+    OS_ENTER_CRITICAL(sr);
+    for (i = 0; i < cnt; i++) {
+        if (bs_uart_rx.head == bs_uart_rx.tail) {
+            break;
+        }
+
+        ch = bs_pull_char();
+        if (ch == '\n') {
+            *str = '\0';
+            *newline = 1;
+            break;
+        }
+        *str++ = ch;
+    }
+    OS_EXIT_CRITICAL(sr);
+    if (i > 0 || *newline) {
+        uart_start_rx(bs_uart);
+    }
+    return i;
+}
+
+static int
+bs_tx_char(void *arg)
+{
+    uint8_t ch;
+
+    if (!bs_uart_tx.cnt) {
+        return -1;
+    }
+
+    bs_uart_tx.cnt--;
+    ch = *bs_uart_tx.ptr;
+    bs_uart_tx.ptr++;
+    return ch;
+}
+
+#if MYNEWT_VAL(SELFTEST)
+/*
+ * OS is not running, so native uart 'driver' cannot run either.
+ * At the moment unit tests don't check the responses to messages it
+ * sends, so we can drop the outgoing data here.
+ */
+void
+boot_uart_write(char *ptr, int cnt)
+{
+}
+
+#else
+
+void
+boot_uart_write(char *ptr, int cnt)
+{
+    int sr;
+
+    OS_ENTER_CRITICAL(sr);
+    bs_uart_tx.ptr = (uint8_t *)ptr;
+    bs_uart_tx.cnt = cnt;
+    OS_EXIT_CRITICAL(sr);
+
+    uart_start_tx(bs_uart);
+    while (bs_uart_tx.cnt);
+}
+
+#endif

--- a/boot/mynewt/mcuboot_config/syscfg.yml
+++ b/boot/mynewt/mcuboot_config/syscfg.yml
@@ -52,6 +52,13 @@ syscfg.defs:
     BOOTUTIL_HAVE_LOGGING:
         description: 'Enable serial logging'
         value: 0
+        restrictions:
+            - "!BOOTUTIL_NO_LOGGING"
+    BOOTUTIL_NO_LOGGING:
+        description: 'No serial logging'
+        value: 1
+        restrictions:
+            - "!BOOTUTIL_HAVE_LOGGING"
     BOOTUTIL_LOG_LEVEL:
         description: >
             Default console log level. Valid values are:

--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -23,7 +23,8 @@
 #include <stddef.h>
 #include <inttypes.h>
 #include <stdio.h>
-#include "syscfg/syscfg.h"
+
+#include <syscfg/syscfg.h>
 #include <flash_map_backend/flash_map_backend.h>
 #include <os/os.h>
 #include <bsp/bsp.h>
@@ -35,6 +36,9 @@
 #include <hal/hal_gpio.h>
 #include <hal/hal_nvreg.h>
 #include <boot_serial/boot_serial.h>
+#endif
+#if defined(MCUBOOT_SERIAL) && MYNEWT_VAL(BOOT_SERIAL_DETECT_TIMEOUT) != 0
+#include <boot_uart/boot_uart.h>
 #endif
 #include <console/console.h>
 #include "bootutil/image.h"
@@ -61,6 +65,70 @@ int flash_device_base(uint8_t fd_id, uintptr_t *ret)
 }
 
 #ifdef MCUBOOT_SERIAL
+#if MYNEWT_VAL(BOOT_SERIAL_DETECT_TIMEOUT) != 0
+
+/** Don't include null-terminator in comparison. */
+#define BOOT_SERIAL_DETECT_STRING_LEN \
+    (sizeof MYNEWT_VAL(BOOT_SERIAL_DETECT_STRING) - 1)
+
+/**
+ * Listens on the UART for the management string.  Blocks for up to
+ * BOOT_SERIAL_DETECT_TIMEOUT milliseconds.
+ *
+ * @return                      true if the management string was received;
+ *                              false if the management string was not received
+ *                                  before the UART listen timeout expired.
+ */
+static bool
+serial_detect_uart_string(void)
+{
+    uint32_t start_tick;
+    char buf[BOOT_SERIAL_DETECT_STRING_LEN] = { 0 };
+    char ch;
+    int newline;
+    int rc;
+
+    /* Calculate the timeout duration in OS cputime ticks. */
+    static const uint32_t timeout_dur =
+        MYNEWT_VAL(BOOT_SERIAL_DETECT_TIMEOUT) /
+        (1000.0 / MYNEWT_VAL(OS_CPUTIME_FREQ));
+
+    rc = boot_serial_uart_open();
+    assert(rc == 0);
+
+    start_tick = os_cputime_get32();
+
+    while (1) {
+        /* Read a single character from the UART. */
+        rc = boot_serial_uart_read(&ch, 1, &newline);
+        if (rc > 0) {
+            /* Eliminate the oldest character in the buffer to make room for
+             * the new one.
+             */
+            memmove(buf, buf + 1, BOOT_SERIAL_DETECT_STRING_LEN - 1);
+            buf[BOOT_SERIAL_DETECT_STRING_LEN - 1] = ch;
+
+            /* If the full management string has been received, indicate that
+             * the serial boot loader should start.
+             */
+            rc = memcmp(buf,
+                        MYNEWT_VAL(BOOT_SERIAL_DETECT_STRING),
+                        BOOT_SERIAL_DETECT_STRING_LEN);
+            if (rc == 0) {
+                boot_serial_uart_close();
+                return true;
+            }
+        }
+
+        /* Abort the listen on timeout. */
+        if (os_cputime_get32() >= start_tick + timeout_dur) {
+            boot_serial_uart_close();
+            return false;
+        }
+    }
+}
+#endif
+
 static void
 serial_boot_detect(void)
 {
@@ -99,7 +167,7 @@ serial_boot_detect(void)
      * download commands from serial.
      */
 #if MYNEWT_VAL(BOOT_SERIAL_DETECT_TIMEOUT) != 0
-    if (boot_serial_detect_uart_string()) {
+    if (serial_detect_uart_string()) {
         boot_serial_start(BOOT_SERIAL_INPUT_MAX);
         assert(0);
     }

--- a/boot/mynewt/syscfg.yml
+++ b/boot/mynewt/syscfg.yml
@@ -29,5 +29,5 @@ syscfg.defs:
 syscfg.vals:
     SYSINIT_CONSTRAIN_INIT: 0
     OS_SCHEDULING: 0
-    OS_CPUTIME_TIMER_NUM: -1
+    MSYS_1_BLOCK_COUNT: 0
     CONSOLE_COMPAT: 1

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -29,7 +29,13 @@
 #include "flash_map_backend/flash_map_backend.h"
 
 #ifdef CONFIG_MCUBOOT_SERIAL
-#include <boot_serial/boot_serial.h>
+#include "boot_serial/boot_serial.h"
+#include "serial_adapter/serial_adapter.h"
+
+const struct boot_uart_funcs boot_funcs = {
+    .read = console_read,
+    .write = console_write
+};
 #endif
 
 struct device *boot_flash_device;
@@ -121,7 +127,9 @@ void main(void)
 
     if (detect_value == CONFIG_BOOT_SERIAL_DETECT_PIN_VAL) {
         BOOT_LOG_INF("Enter the serial recovery mode");
-        boot_serial_start(CONFIG_BOOT_MAX_LINE_INPUT_LEN + 1);
+        rc = boot_console_init();
+        __ASSERT(rc, "Error initializing boot console.\n");
+        boot_serial_start(&boot_funcs);
         __ASSERT(0, "Bootloader serial process was terminated unexpectedly.\n");
     }
 #endif

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -53,9 +53,6 @@ static int boot_uart_fifo_init(void);
 int
 console_out(int c)
 {
-    if ('\n' == c) {
-        uart_poll_out(uart_dev, '\r');
-    }
     uart_poll_out(uart_dev, c);
 
     return c;


### PR DESCRIPTION
Serial bootloader size was too big, so
 - got rid of snprintf() reference
 - got rid of cborattr
And on Mynewt side of size reduction:
 - tuned kernel/os to not bring memory pool code
 - replace minimal console with a more direct way of accessing uart

On some platforms the watchdog keeps running post-reset, and mynewt users have a gpio reporting when waiting for serial DFU. Therefore changed the code to pass platform specific routines to do reads and writes from uart. This allows Mynewt side to do it's watchdog tickling, gpio toggling without polling common code.

Unittests on mynewt side are still broken, but they've been so even before. So I'll create another PR to address those later.

Signed-Off-By: Marko Kiiskila <marko@apache.org>