### PR TITLE
zephyr: Default to RSA .pem file in config fragment

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -10,10 +10,11 @@ CONFIG_MBEDTLS_CFG_FILE="mcuboot-mbedtls-cfg.h"
 CONFIG_BOOT_SIGNATURE_TYPE_RSA=y
 CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256=n
 
-### The bootloader generates its own signature verification based on an
-### key file which needs to be provided and match the selected sign algo.
+### The bootloader generates its own signature verification based on a
+### key file which needs to be provided and needs to match the selected signing
+### algorithm (CONFIG_BOOT_SIGNATURE_TYPE_).
 ### The PEM files below are provided as examples.
-#CONFIG_BOOT_SIGNATURE_KEY_FILE="root-rsa-2048.pem"
+CONFIG_BOOT_SIGNATURE_KEY_FILE="root-rsa-2048.pem"
 #CONFIG_BOOT_SIGNATURE_KEY_FILE="root-ec-p256.pem"
 
 ### mbedTLS has its own heap


### PR DESCRIPTION
In order to provide a pleasant out-of-the-box experience to users,
default to the RSA .pem file so that users do not get a cryptic error
when building with the default .conf file in upstream.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>