### PR TITLE
Allow passing in `--overwrite-only` flag

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -476,6 +476,11 @@ boot_read_status(struct boot_status *bs)
 
     memset(bs, 0, sizeof *bs);
 
+#ifdef MCUBOOT_OVERWRITE_ONLY
+    /* Overwrite-only doesn't make use of the swap status area. */
+    return 0;
+#endif
+
     status_loc = boot_status_source();
     switch (status_loc) {
     case BOOT_STATUS_SOURCE_NONE:
@@ -502,6 +507,7 @@ boot_read_status(struct boot_status *bs)
     rc = boot_read_status_bytes(fap, bs);
 
     flash_area_close(fap);
+
     return rc;
 }
 

--- a/scripts/imgtool.py
+++ b/scripts/imgtool.py
@@ -114,6 +114,8 @@ class BasedIntParamType(click.ParamType):
 
 @click.argument('outfile')
 @click.argument('infile')
+@click.option('--overwrite-only', default=False, is_flag=True,
+              help='Use overwrite-only instead of swap upgrades')
 @click.option('-M', '--max-sectors', type=int,
               help='When padding allow for this amount of sectors (defaults to 128)')
 @click.option('--pad', default=False, is_flag=True,
@@ -129,12 +131,13 @@ class BasedIntParamType(click.ParamType):
 @click.option('-k', '--key', metavar='filename')
 @click.command(help='Create a signed or unsigned image')
 def sign(key, align, version, header_size, included_header, slot_size, pad,
-         max_sectors, infile, outfile):
+         max_sectors, overwrite_only, infile, outfile):
     img = image.Image.load(infile, version=decode_version(version),
                            header_size=header_size,
                            included_header=included_header, pad=pad,
                            align=int(align), slot_size=slot_size,
-                           max_sectors=max_sectors)
+                           max_sectors=max_sectors,
+                           overwrite_only=overwrite_only)
     key = load_key(key) if key else None
     img.sign(key)
 


### PR DESCRIPTION
Overwrite only requires just magic + image_ok + copy_done. This fixes issues generating images in overwrite only mode when the firmware image is too big and overflows the swap status area.