### PR TITLE
Fix assertions in zephyr main file

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -113,11 +113,11 @@ void main(void)
 
     rc = gpio_pin_configure(detect_port, CONFIG_BOOT_SERIAL_DETECT_PIN,
                             GPIO_DIR_IN | GPIO_PUD_PULL_UP);
-    __ASSERT(rc, "Error of boot detect pin initialization.\n");
+    __ASSERT(rc == 0, "Error of boot detect pin initialization.\n");
 
     rc = gpio_pin_read(detect_port, CONFIG_BOOT_SERIAL_DETECT_PIN, 
                        &detect_value);
-    __ASSERT(rc, "Error of the reading the detect pin.\n");
+    __ASSERT(rc == 0, "Error of the reading the detect pin.\n");
 
     if (detect_value == CONFIG_BOOT_SERIAL_DETECT_PIN_VAL) {
         BOOT_LOG_INF("Enter the serial recovery mode");


### PR DESCRIPTION
For serial recovery enabled Assertions conditions were improperly
which cause runtime assertion whenever __ASSERT macro was enabled
along with the serial recovery mode running.

This patch fixes the issue.

Signed-off-by: Andrzej Puzdrowski andrzej.puzdrowski@nordicsemi.no