### PR TITLE
Update `--included-header` usage and documentation

### DIFF
--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -50,23 +50,25 @@ into the key file.
 Image signing takes an image in binary or Intel Hex format intended for Slot 0
 and adds a header and trailer that the bootloader is expecting:
 
-    usage: imgtool.py sign [-h] -k filename --align ALIGN -v VERSION -H
-                           HEADER_SIZE [--pad PAD] [--rsa-pkcs1-15]
-                           infile outfile
-    
-    positional arguments:
-      infile
-      outfile
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      -k filename, --key filename
-      --align ALIGN
-      -v VERSION, --version VERSION
-      -H HEADER_SIZE, --header-size HEADER_SIZE
-      --included-header     Image has gap for header
-      --pad PAD             Pad image to this many bytes, adding trailer magic
-      --rsa-pkcs1-15        Use old PKCS#1 v1.5 signature algorithm
+    Usage: imgtool.py sign [OPTIONS] INFILE OUTFILE
+
+      Create a signed or unsigned image
+
+    Options:
+      -k, --key filename
+      --align [1|2|4|8]          [required]
+      -v, --version TEXT         [required]
+      -H, --header-size INTEGER  [required]
+      --pad-header               Add `--header-size` zeroed bytes at the beginning
+                                 of the image
+      -S, --slot-size INTEGER    Size of the slot where the image will be written
+                                 [required]
+      --pad                      Pad image to --slot-size bytes, adding trailer
+                                 magic
+      -M, --max-sectors INTEGER  When padding allow for this amount of sectors
+                                 (defaults to 128)
+      --overwrite-only           Use overwrite-only instead of swap upgrades
+      -h, --help                 Show this message and exit.
 
 The main arguments given are the key file generated above, a version
 field to place in the header (1.2.3 for example), the alignment of the
@@ -74,16 +76,16 @@ flash device in question, and the header size.
 
 The header size depends on the operating system and the particular
 flash device.  For Zephyr, it will be configured as part of the build,
-and will be a small power of two.  By default, the header will be
-prepended to the image.  If `--included-header` is given, the image
-must start with header-size bytes of zeros, and the header will be
-overwritten over these bytes.
+and will be a small power of two.  By default, the Zephyr build system will
+already prepended a zeroed header to the image.  If another build system is
+in use that does not automatically add this zeroed header, `--pad-header` can
+be passed and the `--header-size` will be added by imgtool.
+
+The `--slot-size` argument is required and used to check that the firmware
+does not overflow into the swap status area (metadata). If swap upgrades are
+not being used, `--overwrite-only` can be passed to avoid adding the swap
+status area size when calculating overflow.
 
 The optional --pad argument will place a trailer on the image that
 indicates that the image should be considered an upgrade.  Writing
 this image in slot 1 will then cause the bootloader to upgrade to it.
-
-Lastly, the --rsa-pkcs1-15 will cause the tool to use the older,
-deprecated pkcs#1 v1.5 signing algorithm when using RSA.  This can be
-enabled in the bootloader as wel, and may be needed if you are using
-an older version of the bootloader.

--- a/samples/zephyr/Makefile
+++ b/samples/zephyr/Makefile
@@ -129,7 +129,6 @@ hello1: check
 		--header-size $(BOOT_HEADER_LEN) \
 		--align $(FLASH_ALIGNMENT) \
 		--version 1.2 \
-		--included-header \
 		--slot-size 0x60000
 		$(BUILD_DIR_HELLO1)/zephyr/zephyr.bin \
 		signed-hello1.bin
@@ -155,7 +154,6 @@ hello2: check
 		--header-size $(BOOT_HEADER_LEN) \
 		--align $(FLASH_ALIGNMENT) \
 		--version 1.2 \
-		--included-header \
 		--slot-size 0x60000 \
 		--pad \
 		$(BUILD_DIR_HELLO2)/zephyr/zephyr.bin \

--- a/scripts/imgtool.py
+++ b/scripts/imgtool.py
@@ -122,20 +122,19 @@ class BasedIntParamType(click.ParamType):
               help='Pad image to --slot-size bytes, adding trailer magic')
 @click.option('-S', '--slot-size', type=BasedIntParamType(), required=True,
               help='Size of the slot where the image will be written')
-@click.option('--included-header', default=False, is_flag=True,
-              help='Image has gap for header')
+@click.option('--pad-header', default=False, is_flag=True,
+              help='Add --header-size zeroed bytes at the beginning of the image')
 @click.option('-H', '--header-size', type=BasedIntParamType(), required=True)
 @click.option('-v', '--version', callback=validate_version,  required=True)
 @click.option('--align', type=click.Choice(['1', '2', '4', '8']),
               required=True)
 @click.option('-k', '--key', metavar='filename')
 @click.command(help='Create a signed or unsigned image')
-def sign(key, align, version, header_size, included_header, slot_size, pad,
+def sign(key, align, version, header_size, pad_header, slot_size, pad,
          max_sectors, overwrite_only, infile, outfile):
     img = image.Image.load(infile, version=decode_version(version),
-                           header_size=header_size,
-                           included_header=included_header, pad=pad,
-                           align=int(align), slot_size=slot_size,
+                           header_size=header_size, pad_header=pad_header,
+                           pad=pad, align=int(align), slot_size=slot_size,
                            max_sectors=max_sectors,
                            overwrite_only=overwrite_only)
     key = load_key(key) if key else None

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -66,7 +66,7 @@ class TLV():
 
 class Image():
     @classmethod
-    def load(cls, path, included_header=False, **kwargs):
+    def load(cls, path, pad_header=False, **kwargs):
         """Load an image from a given file"""
         ext = os.path.splitext(path)[1][1:].lower()
         if ext == INTEL_HEX_EXT:
@@ -78,7 +78,7 @@ class Image():
         obj.payload, obj.base_addr = obj.load(path)
 
         # Add the image header if needed.
-        if not included_header and obj.header_size > 0:
+        if pad_header and obj.header_size > 0:
             obj.payload = (b'\000' * obj.header_size) + obj.payload
 
         obj.check()


### PR DESCRIPTION
The `--included-header` was "mandatory" when using imgtool with firmware images generated by the Zephyr build system and it was a source of issues when it was forgotten. This removes `--included-header` and adds a new parameter `--pad-header` with inverted semantics, to be used only when a zeroed header is required to be added to the firmware image.

Also updated imgtool documentation.