### PR TITLE
Deinit timer after serial load is finished

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -221,6 +221,7 @@ main(void)
     console_blocking_mode();
 #if defined(MCUBOOT_SERIAL)
     serial_boot_detect();
+    hal_timer_deinit(MYNEWT_VAL(OS_CPUTIME_TIMER_NUM));
 #endif
 #else
     flash_map_init();


### PR DESCRIPTION
This fixes an issue where the bootloader is activating a timer that is later not used by the installed target image causing a non handled interrupt fault.

Signed-off-by: Fabio Utzig <utzig@apache.org>