### PR TITLE
include soc.h in main.c

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -20,6 +20,7 @@
 #include <misc/__assert.h>
 #include <flash.h>
 #include <drivers/system_timer.h>
+#include <soc.h>
 
 #include "target.h"
 


### PR DESCRIPTION
While building with Zephyr 1.12 for the nucleo_f091rc I got undefined
reference to __set_MSP() during linking. Including soc.h fixes the
problem. Thanks carlesc.