### PR TITLE
boot_serial: Fix build on Zephyr with ECDSA enabled

### DIFF
--- a/boot/boot_serial/CMakeLists.txt
+++ b/boot/boot_serial/CMakeLists.txt
@@ -1,2 +1,0 @@
-add_subdirectory(src)
-zephyr_include_directories(include)

--- a/boot/boot_serial/src/CMakeLists.txt
+++ b/boot/boot_serial/src/CMakeLists.txt
@@ -1,5 +1,0 @@
-zephyr_sources(boot_serial.c)
-
-zephyr_include_directories(${BOOT_DIR}/bootutil/include)
-
-zephyr_link_libraries_ifdef(CONFIG_TINYCBOR TINYCBOR)

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -128,8 +128,12 @@ endif()
 
 if (CONFIG_MCUBOOT_SERIAL)
 zephyr_sources(${BOOT_DIR}/zephyr/serial_adapter.c)
+zephyr_sources(${BOOT_DIR}/boot_serial/src/boot_serial.c)
 
-add_subdirectory(${BOOT_DIR}/boot_serial ./boot/boot_serial)
+zephyr_include_directories(${BOOT_DIR}/bootutil/include)
+zephyr_include_directories(${BOOT_DIR}/boot_serial/include)
+zephyr_include_directories(include)
+zephyr_link_libraries_ifdef(CONFIG_TINYCBOR TINYCBOR)
 endif()
 
 if(NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")


### PR DESCRIPTION
Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>