### PR TITLE
fix the offset and size regular expressions in assemble.py

### DIFF
--- a/scripts/assemble.py
+++ b/scripts/assemble.py
@@ -34,8 +34,8 @@ def same_keys(a, b):
             return False
     return True
 
-offset_re = re.compile(r"^#define FLASH_AREA_([0-9A-Z_]+)_OFFSET(_0)?\s+((0x)?[0-9a-fA-F]+)")
-size_re   = re.compile(r"^#define FLASH_AREA_([0-9A-Z_]+)_SIZE(_0)?\s+((0x)?[0-9a-fA-F]+)")
+offset_re = re.compile(r"^#define FLASH_AREA_([0-9A-Z_]+)_OFFSET(_0)?\s+(0x[0-9a-fA-F]+|[0-9]+)$")
+size_re   = re.compile(r"^#define FLASH_AREA_([0-9A-Z_]+)_SIZE(_0)?\s+(0x[0-9a-fA-F]+|[0-9]+)$")
 
 class Assembly():
     def __init__(self, output, bootdir):


### PR DESCRIPTION
Given the example lines:

 #define FLASH_AREA_MCUBOOT_OFFSET_0 0x0
 #define FLASH_AREA_MCUBOOT_OFFSET   FLASH_AREA_MCUBOOT_OFFSET_0

Changing OFFSET_0 to OFFSET(_0)? allows the re to possibly match the
second line where it would have stopped the match before. This combined
with the (0x)? means that the re does match the second line, with the
third group being just the F of FLASH_AREA_IMAGE_1_OFFSET_0. The int()
function fails because F is not a valid number. This commit makes the
matching more precise by 1) matching the 0x when there are hex digits
and without the 0x when there are decimal digits and 2) matching until
the end of the line.