### PR TITLE
imgtool: Adjust base_addr when injecting header

### DIFF
--- a/docs/imgtool.md
+++ b/docs/imgtool.md
@@ -79,7 +79,11 @@ flash device.  For Zephyr, it will be configured as part of the build,
 and will be a small power of two.  By default, the Zephyr build system will
 already prepended a zeroed header to the image.  If another build system is
 in use that does not automatically add this zeroed header, `--pad-header` can
-be passed and the `--header-size` will be added by imgtool.
+be passed and the `--header-size` will be added by imgtool. If `--pad-header`
+is used with an Intel Hex file, `--header-size` bytes will be subtracted from
+the load address (in Intel Hex terms, the Extended Linear Address record) to
+adjust for the new bytes prepended to the file. The load address of all data
+existing in the file should not change.
 
 The `--slot-size` argument is required and used to check that the firmware
 does not overflow into the swap status area (metadata). If swap upgrades are

--- a/scripts/imgtool/image.py
+++ b/scripts/imgtool/image.py
@@ -79,6 +79,9 @@ class Image():
 
         # Add the image header if needed.
         if pad_header and obj.header_size > 0:
+            if obj.base_addr:
+                # Adjust base_addr for new header
+                obj.base_addr -= obj.header_size
             obj.payload = (b'\000' * obj.header_size) + obj.payload
 
         obj.check()


### PR DESCRIPTION
Adjusts the "base address" in an intel hex file if using "--pad-header."

If adding a header to a .hex file (using the command line "--pad-header"), the hex file gets shifted by HEADER_SIZE. This may cause hard coded addresses to be off by "header-size", making the firmware unusable. Instead, adjust the base address by the header size, so the existing firmware in the hex file is loaded to the proper addresses.

I'm not sure I've thought through all use cases here. But I've found the using --pad-header results in an invalid firmware image when passing in a hex file.