### PR TITLE
Initialize watchdog when running on Mynewt

### DIFF
--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -213,6 +213,11 @@ main(void)
 
     hal_bsp_init();
 
+#if !MYNEWT_VAL(OS_SCHEDULING) && MYNEWT_VAL(WATCHDOG_INTERVAL)
+    rc = hal_watchdog_init(MYNEWT_VAL(WATCHDOG_INTERVAL));
+    assert(rc == 0);
+#endif
+
 #if defined(MCUBOOT_SERIAL) || defined(MCUBOOT_HAVE_LOGGING)
     /* initialize uart without os */
     os_dev_initialize_all(OS_DEV_INIT_PRIMARY);


### PR DESCRIPTION
On Mynewt some flash drivers on very slow devices tickle the watchdog to avoid possible hangs; those were also trying to tickle the watchdog in mcuboot when performing an upgrade or serial boot, without initializing the watchdog, causing an invalid memory write and reset issue.

Signed-off-by: Fabio Utzig <utzig@apache.org>