### PR TITLE
Erase flash pages progressively

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -212,6 +212,10 @@ bs_upload(char *buf, int len)
     char name_str[8];
     const struct flash_area *fap = NULL;
     int rc;
+#ifdef CONFIG_BOOT_ERASE_PROGRESSIVELY
+    static off_t off_last = -1;
+    struct flash_sector sector;
+#endif
 
     memset(img_data, 0, sizeof(img_data));
 
@@ -323,10 +327,12 @@ bs_upload(char *buf, int len)
         if (data_len > fap->fa_size) {
             goto out_invalid_data;
         }
+#ifndef CONFIG_BOOT_ERASE_PROGRESSIVELY
         rc = flash_area_erase(fap, 0, fap->fa_size);
         if (rc) {
             goto out_invalid_data;
         }
+#endif
         img_size = data_len;
     }
     if (off != curr_off) {
@@ -339,6 +345,25 @@ bs_upload(char *buf, int len)
             img_blen -= rem_bytes;
         }
     }
+
+#ifdef CONFIG_BOOT_ERASE_PROGRESSIVELY
+    rc = flash_area_sector_from_off(curr_off + img_blen, &sector);
+    if (rc) {
+        BOOT_LOG_ERR("Unable to determine flash sector size");
+        goto out;
+    }
+    if (off_last != sector.fs_off) {
+        off_last = sector.fs_off;
+        BOOT_LOG_INF("Moving to sector 0x%x", sector.fs_off);
+        rc = flash_area_erase(fap, sector.fs_off, sector.fs_size);
+        if (rc) {
+            BOOT_LOG_ERR("Error %d while erasing sector", rc);
+            goto out;
+        }
+    }
+#endif
+
+    BOOT_LOG_INF("Writing at 0x%x until 0x%x", curr_off, curr_off + img_blen);
     rc = flash_area_write(fap, curr_off, img_data, img_blen);
     if (rc == 0) {
         curr_off += img_blen;
@@ -346,6 +371,7 @@ bs_upload(char *buf, int len)
     out_invalid_data:
         rc = MGMT_ERR_EINVAL;
     }
+
 out:
     BOOT_LOG_INF("RX: 0x%x", rc);
     cbor_encoder_create_map(&bs_root, &bs_rsp, CborIndefiniteLength);

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -127,13 +127,17 @@ elseif(CONFIG_BOOT_SIGNATURE_TYPE_RSA)
 endif()
 
 if (CONFIG_MCUBOOT_SERIAL)
-zephyr_sources(${BOOT_DIR}/zephyr/serial_adapter.c)
-zephyr_sources(${BOOT_DIR}/boot_serial/src/boot_serial.c)
+  zephyr_sources(${BOOT_DIR}/zephyr/serial_adapter.c)
+  zephyr_sources(${BOOT_DIR}/boot_serial/src/boot_serial.c)
 
-zephyr_include_directories(${BOOT_DIR}/bootutil/include)
-zephyr_include_directories(${BOOT_DIR}/boot_serial/include)
-zephyr_include_directories(include)
-zephyr_link_libraries_ifdef(CONFIG_TINYCBOR TINYCBOR)
+  zephyr_include_directories(${BOOT_DIR}/bootutil/include)
+  zephyr_include_directories(${BOOT_DIR}/boot_serial/include)
+  zephyr_include_directories(include)
+  zephyr_link_libraries_ifdef(CONFIG_TINYCBOR TINYCBOR)
+
+  if (CONFIG_BOOT_ERASE_PROGRESSIVELY)
+    zephyr_include_directories(${BOOT_DIR}/bootutil/src)
+  endif()
 endif()
 
 if(NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -75,6 +75,15 @@ config BOOT_MAX_IMG_SECTORS
 	  memory usage; larger values allow it to support larger images.
 	  If unsure, leave at the default value.
 
+config BOOT_ERASE_PROGRESSIVELY
+	bool "Erase flash progressively when receiving new firmware"
+	default y if SOC_NRF52840
+	help
+	 If enabled, flash is erased as necessary when receiving new firmware,
+	 instead of erasing the whole image slot at once. This is necessary
+	 on some hardware that has long erase times, to prevent long wait
+	 times at the beginning of the DFU process.
+
 config ZEPHYR_TRY_MASS_ERASE
 	bool "Try to mass erase flash when flashing MCUboot image"
 	default y

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -11,7 +11,6 @@
 #include "target.h"
 
 #include <flash_map_backend/flash_map_backend.h>
-#include <hal/hal_flash.h>
 #include <sysflash/sysflash.h>
 
 #include "bootutil/bootutil_log.h"
@@ -23,6 +22,16 @@
  */
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
+
+static struct device *flash_dev;
+
+struct device *flash_device_get_binding(char *dev_name)
+{
+    if (!flash_dev) {
+        flash_dev = device_get_binding(dev_name);
+    }
+    return flash_dev;
+}
 
 int flash_device_base(uint8_t fd_id, uintptr_t *ret)
 {
@@ -42,4 +51,20 @@ int flash_device_base(uint8_t fd_id, uintptr_t *ret)
 int flash_area_id_from_image_slot(int slot)
 {
     return slot + FLASH_AREA_IMAGE_0;
+}
+
+int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
+{
+    int rc;
+    struct flash_pages_info page;
+
+    rc = flash_get_page_info_by_offs(flash_dev, off, &page);
+    if (rc) {
+        return rc;
+    }
+
+    sector->fs_off = page.start_offset;
+    sector->fs_size = page.size;
+
+    return rc;
 }

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -8,7 +8,7 @@
 #ifndef __FLASH_MAP_BACKEND_H__
 #define __FLASH_MAP_BACKEND_H__
 
-#include <flash_map.h> // the zephyr falsh_map
+#include <flash_map.h> // the zephyr flash_map
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,7 +32,13 @@ extern "C" {
  * and match the target offset specified in download script.
  */
 #include <inttypes.h>
+#include <sys/types.h>
 
+/* Retrieve the flash device with the given name.
+ *
+ * Returns the flash device on success, or NULL on failure.
+ */
+struct device *flash_device_get_binding(char *dev_name);
 
 /*
  * Retrieve a memory-mapped flash device's base address.
@@ -45,6 +51,12 @@ extern "C" {
 int flash_device_base(uint8_t fd_id, uintptr_t *ret);
 
 int flash_area_id_from_image_slot(int slot);
+
+/* Retrieve the flash sector a given offset belongs to.
+ *
+ * Returns 0 on success, or an error code on failure.
+ */
+int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
 
 #ifdef __cplusplus
 }

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -39,8 +39,6 @@ const struct boot_uart_funcs boot_funcs = {
 };
 #endif
 
-struct device *boot_flash_device;
-
 void os_heap_init(void);
 
 #if defined(CONFIG_ARM)
@@ -103,8 +101,7 @@ void main(void)
 
     os_heap_init();
 
-    boot_flash_device = device_get_binding(FLASH_DEV_NAME);
-    if (!boot_flash_device) {
+    if (!flash_device_get_binding(FLASH_DEV_NAME)) {
         BOOT_LOG_ERR("Flash device %s not found", FLASH_DEV_NAME);
         while (1)
             ;


### PR DESCRIPTION
- Fixed ISR in serial_adapter to work with USB CDC ACM serial emulation. This commit prepares mcuboot for coming USB support patch.
- Added an option to erase flash pages progressively to avoid possible timeouts

This PR contains code which was separated form previous PR #318

Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>
Signed-off-by: Emanuele Di Santo <andrzej.puzdrowski@nordicsemi.no>
