### PR TITLE
Support flash devices erased at 0

### DIFF
--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -59,9 +59,24 @@ struct boot_status {
     uint32_t swap_size;   /* Total size of swapped image */
 };
 
-#define BOOT_MAGIC_GOOD  1
-#define BOOT_MAGIC_BAD   2
-#define BOOT_MAGIC_UNSET 3
+#define BOOT_MAGIC_GOOD     1
+#define BOOT_MAGIC_BAD      2
+#define BOOT_MAGIC_UNSET    3
+#define BOOT_MAGIC_ANY      4  /* NOTE: control only, not dependent on sector */
+
+/*
+ * NOTE: leave BOOT_FLAG_SET equal to one, this is written to flash!
+ */
+#define BOOT_FLAG_SET       1
+#define BOOT_FLAG_BAD       2
+#define BOOT_FLAG_UNSET     3
+#define BOOT_FLAG_ANY       4  /* NOTE: control only, not dependent on sector */
+
+#define BOOT_STATUS_IDX_0   1
+
+#define BOOT_STATUS_STATE_0 1
+#define BOOT_STATUS_STATE_1 2
+#define BOOT_STATUS_STATE_2 3
 
 /**
  * End-of-image slot structure.
@@ -75,11 +90,11 @@ struct boot_status {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * |                          Swap size                            |
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * ~                  0xff padding (MAX ALIGN - 4)                 ~
+ * ~             padding with erased val (MAX ALIGN - 4)           ~
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * |   Copy done   |          0xff padding (MAX ALIGN - 1)         ~
+ * |   Copy done   |   padding with erased val (MAX ALIGN - 1)     ~
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * |   Image OK    |          0xff padding (MAX ALIGN - 1)         ~
+ * |   Image OK    |   padding with erased val (MAX ALIGN - 1)     ~
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ~                        MAGIC (16 octets)                      ~
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -119,9 +134,6 @@ struct boot_swap_state {
 
 #define BOOT_FLAG_IMAGE_OK         0
 #define BOOT_FLAG_COPY_DONE        1
-
-#define BOOT_FLAG_SET              0x01
-#define BOOT_FLAG_UNSET            0xff
 
 extern const uint32_t BOOT_MAGIC_SZ;
 

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -68,3 +68,9 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
 
     return rc;
 }
+
+uint8_t flash_area_erased_val(const struct flash_area *fap)
+{
+    (void)fap;
+    return 0xff;
+}

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -58,6 +58,12 @@ int flash_area_id_from_image_slot(int slot);
  */
 int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
 
+/*
+ * Returns the value expected to be read when accesing any erased
+ * flash byte.
+ */
+uint8_t flash_area_erased_val(const struct flash_area *fap);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sim/mcuboot-sys/csupport/flash_map.h
+++ b/sim/mcuboot-sys/csupport/flash_map.h
@@ -126,6 +126,11 @@ int flash_area_erase(const struct flash_area *, uint32_t off, uint32_t len);
 uint8_t flash_area_align(const struct flash_area *);
 
 /*
+ * What is value is read from erased flash bytes.
+ */
+uint8_t flash_area_erased_val(const struct flash_area *);
+
+/*
  * Given flash area ID, return info about sectors within the area.
  */
 int flash_area_get_sectors(int fa_id, uint32_t *count,

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -52,6 +52,13 @@ uint8_t flash_area_align(const struct flash_area *area)
     return sim_flash_align;
 }
 
+uint8_t sim_flash_erased_val = 0xff;
+uint8_t flash_area_erased_val(const struct flash_area *area)
+{
+    (void)area;
+    return sim_flash_erased_val;
+}
+
 struct area {
     struct flash_area whole;
     struct flash_area *areas;

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -127,12 +127,6 @@ int hal_flash_erase(uint8_t flash_id, uint32_t address,
     return sim_flash_erase(address, num_bytes);
 }
 
-uint8_t hal_flash_align(uint8_t flash_id)
-{
-    (void)flash_id;
-    return sim_flash_align;
-}
-
 void *os_malloc(size_t size)
 {
     // printf("os_malloc 0x%x bytes\n", size);

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -22,6 +22,7 @@ pub fn boot_go(flash: &mut Flash, areadesc: &AreaDesc, counter: Option<&mut i32>
         raw::c_catch_asserts = if catch_asserts { 1 } else { 0 };
         raw::c_asserts = 0u8;
         raw::sim_flash_align = align;
+        raw::sim_flash_erased_val = flash.erased_val();
         raw::flash_counter = match counter {
             None => 0,
             Some(ref c) => **c as libc::c_int
@@ -73,6 +74,7 @@ mod raw {
         pub static mut c_catch_asserts: u8;
 
         pub static mut sim_flash_align: u8;
+        pub static mut sim_flash_erased_val: u8;
         pub fn boot_slots_trailer_sz(min_write_sz: u8) -> u32;
 
         pub static BOOT_MAGIC_SZ: u32;


### PR DESCRIPTION
This updates `mcuboot` and the simulator to allow flash devices that are not erased to 0xff, which is the case on STM32L1 and STM32L0 (maybe others!) both of which employ a flash technology that erases to 0.

An associated PR for Mynewt (https://github.com/apache/mynewt-core/pull/1323) must be merged first. A small `Zephyr` mock will be added soon.