### PR TITLE
Zephyr configuration fixes

### DIFF
--- a/boot/zephyr/include/config-rsa.h
+++ b/boot/zephyr/include/config-rsa.h
@@ -48,14 +48,6 @@
 #define MBEDTLS_HAVE_ASM
 #endif
 
-#if defined(CONFIG_MBEDTLS_TEST)
-#define MBEDTLS_SELF_TEST
-#define MBEDTLS_DEBUG_C
-#else
-#define MBEDTLS_ENTROPY_C
-#define MBEDTLS_TEST_NULL_ENTROPY
-#endif
-
 #define MBEDTLS_RSA_C
 #define MBEDTLS_PKCS1_V21
 

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -32,6 +32,7 @@ CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
 CONFIG_MULTITHREADING=n
 
-### Zephyr keeps turning on major subsystems by default that we don't want.
+### Various Zephyr boards enable features that we don't want.
 # CONFIG_BT is not set
+# CONFIG_BT_CTLR is not set
 # CONFIG_I2C is not set


### PR DESCRIPTION
MCUboot is generating unnecessary warnings during its build. Fix them.