### PR TITLE
Update mbedtls submodule to 2.12.0

### DIFF
--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -40,6 +40,8 @@ fn main() {
 
         conf.file("mbedtls/library/rsa.c");
         conf.file("mbedtls/library/bignum.c");
+        conf.file("mbedtls/library/platform.c");
+        conf.file("mbedtls/library/platform_util.c");
         conf.file("mbedtls/library/asn1parse.c");
     } else if sig_ecdsa {
         conf.define("MCUBOOT_SIGN_EC256", None);

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -66,16 +66,19 @@ struct area_desc {
 
 static struct area_desc *flash_areas;
 
-void *(*mbedtls_calloc)(size_t n, size_t size);
-void (*mbedtls_free)(void *ptr);
+#ifdef MCUBOOT_SIGN_RSA
+int mbedtls_platform_set_calloc_free(void * (*calloc_func)(size_t, size_t),
+                                     void (*free_func)(void *));
+#endif
 
 int invoke_boot_go(struct area_desc *adesc)
 {
     int res;
     struct boot_rsp rsp;
 
-    mbedtls_calloc = calloc;
-    mbedtls_free = free;
+#ifdef MCUBOOT_SIGN_RSA
+    mbedtls_platform_set_calloc_free(calloc, free);
+#endif
 
     flash_areas = adesc;
     if (setjmp(boot_jmpbuf) == 0) {


### PR DESCRIPTION
This also updates the RSA test to add extra build files for zeroize, and updates to new calloc/free configuration style.

Signed-off-by: Fabio Utzig <utzig@apache.org>