### PR TITLE
Test erased flash with flash_area_read_is_empty()

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -97,34 +97,17 @@ static const struct boot_swap_table boot_swap_tables[] = {
     (sizeof boot_swap_tables / sizeof boot_swap_tables[0])
 
 static int
-boot_magic_decode(const struct flash_area *fap, const uint32_t *magic)
+boot_magic_decode(const uint32_t *magic)
 {
-    size_t i;
-    uint8_t erased_val;
-
     if (memcmp(magic, boot_img_magic, BOOT_MAGIC_SZ) == 0) {
         return BOOT_MAGIC_GOOD;
     }
-
-    erased_val = flash_area_erased_val(fap);
-    for (i = 0; i < BOOT_MAGIC_SZ; i++) {
-        if (((uint8_t *)magic)[i] != erased_val) {
-            return BOOT_MAGIC_BAD;
-        }
-    }
-
-    return BOOT_MAGIC_UNSET;
+    return BOOT_MAGIC_BAD;
 }
 
 static int
-boot_flag_decode(const struct flash_area *fap, uint8_t flag)
+boot_flag_decode(uint8_t flag)
 {
-    uint8_t erased_val;
-
-    erased_val = flash_area_erased_val(fap);
-    if (flag == erased_val) {
-        return BOOT_FLAG_UNSET;
-    }
     if (flag != BOOT_FLAG_SET) {
         return BOOT_FLAG_BAD;
     }
@@ -225,27 +208,40 @@ boot_read_swap_state(const struct flash_area *fap,
     int rc;
 
     off = boot_magic_off(fap);
-    rc = flash_area_read(fap, off, magic, BOOT_MAGIC_SZ);
-    if (rc != 0) {
+    rc = flash_area_read_is_empty(fap, off, magic, BOOT_MAGIC_SZ);
+    if (rc < 0) {
         return BOOT_EFLASH;
     }
-    state->magic = boot_magic_decode(fap, magic);
+    if (rc == 1) {
+        state->magic = BOOT_MAGIC_UNSET;
+    } else {
+        state->magic = boot_magic_decode(magic);
+    }
 
     if (fap->fa_id != FLASH_AREA_IMAGE_SCRATCH) {
         off = boot_copy_done_off(fap);
-        rc = flash_area_read(fap, off, &state->copy_done, sizeof state->copy_done);
-        if (rc != 0) {
+        rc = flash_area_read_is_empty(fap, off, &state->copy_done,
+                sizeof state->copy_done);
+        if (rc < 0) {
             return BOOT_EFLASH;
         }
-        state->copy_done = boot_flag_decode(fap, state->copy_done);
+        if (rc == 1) {
+            state->copy_done = BOOT_FLAG_UNSET;
+        } else {
+            state->copy_done = boot_flag_decode(state->copy_done);
+        }
     }
 
     off = boot_image_ok_off(fap);
-    rc = flash_area_read(fap, off, &state->image_ok, sizeof state->image_ok);
-    if (rc != 0) {
+    rc = flash_area_read_is_empty(fap, off, &state->image_ok, sizeof state->image_ok);
+    if (rc < 0) {
         return BOOT_EFLASH;
     }
-    state->image_ok = boot_flag_decode(fap, state->image_ok);
+    if (rc == 1) {
+        state->image_ok = BOOT_FLAG_UNSET;
+    } else {
+        state->image_ok = boot_flag_decode(state->image_ok);
+    }
 
     return 0;
 }

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -404,23 +404,21 @@ boot_read_status_bytes(const struct flash_area *fap, struct boot_status *bs)
     int invalid;
     int rc;
     int i;
-    uint8_t erased_val;
 
     off = boot_status_off(fap);
     max_entries = boot_status_entries(fap);
-    erased_val = flash_area_erased_val(fap);
 
     found = 0;
     found_idx = 0;
     invalid = 0;
     for (i = 0; i < max_entries; i++) {
-        rc = flash_area_read(fap, off + i * BOOT_WRITE_SZ(&boot_data),
-                             &status, 1);
-        if (rc != 0) {
+        rc = flash_area_read_is_empty(fap, off + i * BOOT_WRITE_SZ(&boot_data),
+                &status, 1);
+        if (rc < 0) {
             return BOOT_EFLASH;
         }
 
-        if (status == erased_val) {
+        if (rc == 1) {
             if (found && !found_idx) {
                 found_idx = i;
             }

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -69,8 +69,30 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
     return rc;
 }
 
+#define ERASED_VAL 0xff
 uint8_t flash_area_erased_val(const struct flash_area *fap)
 {
     (void)fap;
-    return 0xff;
+    return ERASED_VAL;
+}
+
+int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
+        void *dst, uint32_t len)
+{
+    uint8_t i;
+    uint8_t *u8dst;
+    int rc;
+
+    rc = hal_flash_read(fa->fa_device_id, fa->fa_off + off, dst, len);
+    if (rc) {
+        return -1;
+    }
+
+    for (i = 0, u8dst = (uint8_t *)dst; i < len; i++) {
+        if (u8dst[i] != ERASED_VAL) {
+            return 0;
+        }
+    }
+
+    return 1;
 }

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -64,6 +64,14 @@ int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
  */
 uint8_t flash_area_erased_val(const struct flash_area *fap);
 
+/*
+ * Reads len bytes from off, and checks if the read data is erased.
+ *
+ * Returns 1 if erased, 0 if non-erased, and -1 on failure.
+ */
+int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
+        void *dst, uint32_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sim/mcuboot-sys/csupport/flash_map.h
+++ b/sim/mcuboot-sys/csupport/flash_map.h
@@ -131,6 +131,14 @@ uint8_t flash_area_align(const struct flash_area *);
 uint8_t flash_area_erased_val(const struct flash_area *);
 
 /*
+ * Reads len bytes from off, and checks if the read data is erased.
+ *
+ * Returns 1 if erased, 0 if non-erased, and -1 on failure.
+ */
+int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
+        void *dst, uint32_t len);
+
+/*
  * Given flash area ID, return info about sectors within the area.
  */
 int flash_area_get_sectors(int fa_id, uint32_t *count,

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -200,6 +200,29 @@ int flash_area_erase(const struct flash_area *area, uint32_t off, uint32_t len)
                            len);
 }
 
+int flash_area_read_is_empty(const struct flash_area *area, uint32_t off,
+        void *dst, uint32_t len)
+{
+    uint8_t i;
+    uint8_t *u8dst;
+    int rc;
+
+    BOOT_LOG_DBG("%s: area=%d, off=%x, len=%x", __func__, area->fa_id, off, len);
+
+    rc = hal_flash_read(area->fa_device_id, area->fa_off + off, dst, len);
+    if (rc) {
+        return -1;
+    }
+
+    for (i = 0, u8dst = (uint8_t *)dst; i < len; i++) {
+        if (u8dst[i] != sim_flash_erased_val) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
 int flash_area_to_sectors(int idx, int *cnt, struct flash_area *ret)
 {
     uint32_t i;


### PR DESCRIPTION
Mynewt has recently added an encrypted flash layer driver, that runs transparently on any flash, handling reads and writes, and bypassing other flash operations to the HW driver. As a result of this change, checking for erased data cannot be done by read + compare to `erased_val` but need to be routed to an empty check on the lower level. To do this Mynewt added a new `flash_map` function called `flash_area_read_is_empty` which checks for erased blocks (and reads/decrypts the data as well).
    
This commit uses `flash_area_read_is_empty` to determine if magic, flags and swap status are erased. For Zephyr/sim commits were added previously that mimic this functionality by simply doing the read/compare.

PS: This might be required on very slow MCUs under Mynewt: https://github.com/apache/mynewt-core/pull/1423