### PR TITLE
Fix setting confirm flag

### DIFF
--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -571,7 +571,7 @@ boot_set_confirmed(void)
         goto done;
     }
 
-    if (state_slot0.image_ok != erased_val) {
+    if (state_slot0.image_ok != BOOT_FLAG_UNSET) {
         /* Already confirmed. */
         goto done;
     }


### PR DESCRIPTION
It was impossible to set confirm flag due to incorrect comparison.
In this point of time state->image_ok is already decoded and contains
one of following values:

If BOOT_FLAG_UNSET then we are ok to set a confirm flag.