### PR TITLE
[imgtool] Add big endian support

### DIFF
--- a/scripts/imgtool.py
+++ b/scripts/imgtool.py
@@ -114,6 +114,8 @@ class BasedIntParamType(click.ParamType):
 
 @click.argument('outfile')
 @click.argument('infile')
+@click.option('-e', '--endian', type=click.Choice(['little', 'big']),
+              default='little', help="Select little or big endian")
 @click.option('--overwrite-only', default=False, is_flag=True,
               help='Use overwrite-only instead of swap upgrades')
 @click.option('-M', '--max-sectors', type=int,
@@ -131,12 +133,13 @@ class BasedIntParamType(click.ParamType):
 @click.option('-k', '--key', metavar='filename')
 @click.command(help='Create a signed or unsigned image')
 def sign(key, align, version, header_size, pad_header, slot_size, pad,
-         max_sectors, overwrite_only, infile, outfile):
+         max_sectors, overwrite_only, endian, infile, outfile):
     img = image.Image.load(infile, version=decode_version(version),
                            header_size=header_size, pad_header=pad_header,
                            pad=pad, align=int(align), slot_size=slot_size,
                            max_sectors=max_sectors,
-                           overwrite_only=overwrite_only)
+                           overwrite_only=overwrite_only,
+                           endian=endian)
     key = load_key(key) if key else None
     img.sign(key)
 


### PR DESCRIPTION
Add big endian support to imgtool so that it can be used on big endian targets.

Signed-off-by: Mark Schulte <mschulte@lyft.com>