### PR TITLE
zephyr: fix flash_area_read_is_empty

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -83,7 +83,7 @@ int flash_area_read_is_empty(const struct flash_area *fa, uint32_t off,
     uint8_t *u8dst;
     int rc;
 
-    rc = hal_flash_read(fa->fa_device_id, fa->fa_off + off, dst, len);
+    rc = flash_area_read(fa, off, dst, len);
     if (rc) {
         return -1;
     }


### PR DESCRIPTION
Implementation of flash_area_read_is_empty introduced recently
uses deprecated hal_flash_read API which caused build failure.

This patch uses zephyr's native flash_area_read() API which
solves the bug.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>