### PR TITLE
Mynewt: Add `version.yml` file

### DIFF
--- a/version.yml
+++ b/version.yml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Newt uses this file to determine the version of a checked out repo.
+# This should always be 0.0.0 in the master branch.
+repo.version: 0.0.0


### PR DESCRIPTION
This file lets newt determine the version of the mcuboot repo.  Without this file, newt reports this annoying warning on each operation:

```
WARNING: Could not detect version of installed repo "mcuboot"; assuming 0.0.0/178be54bd6e5f035cc60e98205535682acd26e64
```