### PR TITLE
Fix implicit declaration of sys_clock_disable() #353

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -40,7 +40,8 @@ const struct boot_uart_funcs boot_funcs = {
 };
 #endif
 
-void os_heap_init(void);
+extern void sys_clock_disable(void);
+extern void os_heap_init(void);
 
 #if defined(CONFIG_ARM)
 struct arm_vector_table {


### PR DESCRIPTION
Created a forward decleration for sys_clock_disable() in the mcuboot for zephyr. Fixes #353 

Signed-off-by: Sigvart M. Hovland <sigvart.hovland@nordicsemi.no>