### PR TITLE
boot: zephyr: add MCUBOOT config

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -7,6 +7,11 @@ mainmenu "MCUboot configuration"
 
 comment "MCUboot-specific configuration options"
 
+# Hidden option to mark a project as MCUboot
+config MCUBOOT
+	default y
+	bool
+
 config BOOT_USE_MBEDTLS
 	bool
 	# Hidden option


### PR DESCRIPTION
Add a hidden MCUBOOT config entry to mark a project as MCUBOOT.
It is useful when other parts of the system need to be aware that they are, in fact, the bootloader.

@nvlsianpu 