### PR TITLE
fix zephyr target: corrupted build after zephyr PR #11180

### DIFF
--- a/boot/zephyr/include/target.h
+++ b/boot/zephyr/include/target.h
@@ -33,7 +33,7 @@
 /*
  * Sanity check the target support.
  */
-#if !defined(FLASH_DEV_NAME) || \
+#if !defined(DT_FLASH_DEV_NAME) || \
     !defined(FLASH_ALIGN) ||                  \
     !defined(FLASH_AREA_IMAGE_0_OFFSET) || \
     !defined(FLASH_AREA_IMAGE_0_SIZE) || \

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -108,8 +108,8 @@ void main(void)
 
     os_heap_init();
 
-    if (!flash_device_get_binding(FLASH_DEV_NAME)) {
-        BOOT_LOG_ERR("Flash device %s not found", FLASH_DEV_NAME);
+    if (!flash_device_get_binding(DT_FLASH_DEV_NAME)) {
+        BOOT_LOG_ERR("Flash device %s not found", DT_FLASH_DEV_NAME);
         while (1)
             ;
     }


### PR DESCRIPTION
Zephyr target was corrupted as recntly zephyr's device tree
started adding DT_ prefix in generated labels.

This path aligns flash name macro used.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>